### PR TITLE
docs(agents): add scoped AGENTS.md by profile and thin root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Agents (Cursor) for DeckDex MTG
 
+**Precedence:** The **closest `AGENTS.md`** to the files you are changing wins. Root holds global defaults only.
+
 Purpose
 -------
 This document lists the local agents and skills available for the DeckDex MTG repository, explains their responsibilities and when to use them, and provides quick examples for invoking or extending them in the Cursor environment.
@@ -71,6 +73,12 @@ Troubleshooting
 ---------------
 - If a skill reports "blocked" or "missing artifacts", open the related spec files in `openspec/` and resolve the missing pieces.
 - If a skill produces problematic edits, revert the changes locally, update the SKILL.md to clarify behavior, and re-run.
+
+Index of scoped AGENTS.md
+-------------------------
+- `backend/AGENTS.md` — API (FastAPI, routes, services, WebSockets)
+- `frontend/AGENTS.md` — Web dashboard (React, TypeScript, Vite)
+- `deckdex/AGENTS.md` — Core package (processor, storage, config)
 
 Contact / Maintainers
 ---------------------

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md — backend
+
+## Overview
+
+Backend API for DeckDex MTG web interface: FastAPI app, REST routes, WebSockets for progress, and a wrapper around the deckdex processor. Runs in Docker or locally with uvicorn.
+
+## Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Install | `pip install -r requirements-api.txt` (from repo root: `pip install -r requirements.txt` then backend deps) | Run from project root or backend/ |
+| Run API | `uvicorn backend.api.main:app --reload` (from repo root) or see README | Dev server |
+| Lint / typecheck | From repo root: `pytest`, lint as per project | Backend shares root Python tooling |
+
+See root `AGENTS.md` for project-wide skills and workflow. Backend-specific tests live in `tests/` at repo root; run from root.
+
+## File map
+
+```
+backend/
+  api/              → FastAPI app, routes, dependencies
+  api/main.py       → App entrypoint
+  api/routes/       → REST endpoints (cards, import, process, settings, stats)
+  api/services/     → processor_service, settings_store
+  api/websockets/  → progress WebSocket
+  Dockerfile        → Image for API service
+  requirements-api.txt → API dependencies
+```
+
+## Conventions
+
+- Use FastAPI dependency injection (`dependencies.py`); avoid global state.
+- Routes are thin: validate input, call services, return Pydantic models.
+- WebSockets: use `api/websockets/progress.py` pattern for job progress.
+- Check root AGENTS.md for project-wide conventions and OpenSpec workflow.

--- a/deckdex/AGENTS.md
+++ b/deckdex/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md — deckdex
+
+## Overview
+
+Core DeckDex package: card processing, config loading, spreadsheet client, storage layer, and CLI/processor entrypoints. Used by the backend API and by standalone CLI. Python 3.x; no framework—plain modules.
+
+## Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Run tests | `pytest tests/` (from repo root) | Tests for deckdex and backend live under tests/ |
+| Run processor | From repo root: `python main.py` or as per README | CLI entrypoint |
+
+See root `AGENTS.md` for project-wide skills and workflow.
+
+## File map
+
+```
+deckdex/
+  config.py         → Config dataclass / validation
+  config_loader.py  → Load YAML and env
+  card_fetcher.py   → Card data fetching
+  magic_card_processor.py → Core processing logic
+  spreadsheet_client.py   → Google Sheets client (gspread)
+  dry_run_client.py → Dry-run behavior
+  logger_config.py  → Logging setup
+  storage/          → Persistence layer
+  storage/repository.py → DB access (e.g. SQLAlchemy)
+```
+
+## Conventions
+
+- No FastAPI or React here; keep imports limited to stdlib and dependencies in root `requirements.txt`.
+- Config: use `config_loader` and `config.py`; avoid hardcoded paths or secrets.
+- Storage: go through `storage/repository` for DB operations.
+- Check root AGENTS.md for project-wide conventions and OpenSpec workflow.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md — frontend
+
+## Overview
+
+Web dashboard for DeckDex MTG: React 19, TypeScript, Vite 7, Tailwind CSS. Talks to the backend API and WebSockets for job progress. Builds to static assets for production.
+
+## Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Install | `npm install` | From frontend/ |
+| Dev server | `npm run dev` | Vite dev server |
+| Build | `npm run build` | TypeScript check + Vite build |
+| Lint | `npm run lint` | ESLint |
+| Preview | `npm run preview` | Preview production build |
+
+See root `AGENTS.md` for project-wide skills and workflow.
+
+## File map
+
+```
+frontend/
+  src/
+    api/          → API client (client.ts)
+    components/   → Reusable UI (CardTable, Filters, JobLogModal, etc.)
+    contexts/     → ThemeContext
+    hooks/        → useApi
+    pages/        → Dashboard, Settings
+    App.tsx       → Root component, routing
+    main.tsx      → Entrypoint
+  index.html      → HTML shell
+  vite.config.ts  → Vite config
+  package.json    → Scripts and dependencies
+```
+
+## Conventions
+
+- Functional components and hooks; TypeScript strict.
+- Use `useApi` and `api/client.ts` for backend calls; WebSockets for job progress where needed.
+- Styling: Tailwind; theme via ThemeContext.
+- Check root AGENTS.md for project-wide conventions and OpenSpec workflow.

--- a/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/design.md
+++ b/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The repo has a single root `AGENTS.md` that documents Cursor skills (OpenSpec, create-rule, etc.) and general workflow. There is no stack-specific guidance for backend (FastAPI), frontend (React/Vite), or the deckdex core package. The agents.md convention (e.g. Netresearch skill) recommends a thin root plus scoped AGENTS.md per area, with "closest AGENTS.md wins" so that only relevant context is loaded per request. This change introduces that structure without altering application code or dependencies.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce token usage for LLM interactions by loading only root + one scoped AGENTS.md when work is in a single area.
+- Establish a thin root AGENTS.md with precedence rule and an index of scoped files.
+- Add backend, frontend, and deckdex scoped AGENTS.md with commands, file map, conventions, and golden samples for each stack.
+- Align with the pointer principle: root points to scoped files; no duplication of stack-specific content in root.
+
+**Non-Goals:**
+
+- Changing how Cursor or other tools select which AGENTS.md to inject (we document precedence; tool behavior is out of scope).
+- Adding or changing .cursor/rules or other Cursor config beyond AGENTS.md files.
+- Modifying application code, APIs, or dependencies.
+
+## Decisions
+
+1. **Three scopes: backend, frontend, deckdex**  
+   Matches the three main areas of the repo (`backend/`, `frontend/`, `deckdex/`). Alternatives: a single "web" scope (backend + frontend) or more granular (e.g. `backend/api/`). Chosen for simplicity and clear stack boundaries; each scope has a distinct language and toolchain.
+
+2. **Root remains the single place for skills**  
+   OpenSpec and Cursor helper skills are project-wide and stay in root only. Scoped files do not list skills; they reference "root AGENTS.md for project-wide conventions/skills" where useful. This avoids duplication and keeps skills in one place.
+
+3. **Scoped file structure follows convention**  
+   Each scoped AGENTS.md includes: short overview, commands (verified where possible), file map, golden samples, and conventions/boundaries. Format and section names align with the agents skill references (e.g. thin root, scoped templates) so future automation or regeneration is easier.
+
+4. **No automated generation for this change**  
+   We write the four files (root + three scoped) by hand. Using the project's agents-skill scripts (e.g. generate-agents.sh) could be a later improvement; not in scope here to avoid dependency on that toolchain and to keep the change self-contained.
+
+## Risks / Trade-offs
+
+- **Cursor may load all AGENTS.md files**  
+  If the IDE always injects every AGENTS.md in the repo, token savings are limited to avoiding duplication and keeping each file smaller. Mitigation: document precedence clearly so that at least the agent's behavior (which instructions win) is well-defined; actual injection is tool-dependent.
+
+- **Drift between scoped files and code**  
+  Commands, file maps, and golden samples can become outdated. Mitigation: keep scoped files concise, reference real paths and commands; recommend periodic review or a later step to run verify-content/verify-commands from the agents skill if adopted.
+
+- **Discovery**  
+  New contributors might not notice scoped AGENTS.md. Mitigation: root index lists them explicitly; precedence sentence in root directs readers to the nearest AGENTS.md.
+
+## Migration Plan
+
+- No runtime or deployable artifact; documentation only.
+- Steps: (1) Create `backend/AGENTS.md`, `frontend/AGENTS.md`, `deckdex/AGENTS.md` with content per spec. (2) Refactor root `AGENTS.md`: add precedence and "Index of scoped AGENTS.md", remove any content that moves to scoped files (if present), keep skills and workflow. (3) No rollback beyond reverting the four file changes.
+
+## Open Questions
+
+- None for implementation. Optional follow-up: integrate with `.cursor/skills/agents` scripts (e.g. detect-scopes, generate-agents) for future updates.

--- a/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/proposal.md
+++ b/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+LLMs interacting with the repo today receive a single root AGENTS.md that mixes project-wide skills with no stack-specific guidance. Loading one large context for every request wastes tokens when work is scoped to one area (e.g. frontend-only). Splitting agent documentation by profile (backend, frontend, deckdex) with a thin root and an index reduces token usage and keeps each conversation focused on the relevant stack.
+
+## What Changes
+
+- **Thin root AGENTS.md**: Keep purpose, skills list, and workflow; add precedence rule ("closest AGENTS.md wins") and an **Index of scoped AGENTS.md** pointing to backend, frontend, and deckdex. No duplication of stack-specific content in root.
+- **backend/AGENTS.md**: New scoped file for API (FastAPI, routes, services, Docker). Commands, file map, conventions, and golden samples for the backend only.
+- **frontend/AGENTS.md**: New scoped file for the web app (React, TypeScript, Vite). Commands, file map, conventions, and golden samples for the frontend only.
+- **deckdex/AGENTS.md**: New scoped file for the core library/CLI (processor, storage, config). Commands, file map, and conventions for the deckdex package only.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-documentation-scoped`: Defines how AGENTS.md is structured by profile (root + backend, frontend, deckdex), precedence rules, index in root, and what each scoped file must contain so that token usage is optimized and agents get only the context relevant to the files they are editing.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- **Root AGENTS.md**: Refactored to be thin; adds precedence and index; skills section unchanged.
+- **New files**: `backend/AGENTS.md`, `frontend/AGENTS.md`, `deckdex/AGENTS.md` (documentation only; no application code or dependencies changed).

--- a/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/specs/agent-documentation-scoped/spec.md
+++ b/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/specs/agent-documentation-scoped/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Thin root AGENTS.md with precedence and index
+
+The repository root SHALL contain a single `AGENTS.md` that is kept thin. It MUST state the precedence rule (e.g. "the closest AGENTS.md to the files you are changing wins; root holds global defaults only"). It MUST include an "Index of scoped AGENTS.md" section that lists exactly the scoped files: `backend/AGENTS.md`, `frontend/AGENTS.md`, and `deckdex/AGENTS.md`, each with a brief description of the scope. Root SHALL NOT duplicate stack-specific content (commands, file maps, golden samples) that belong in scoped files; it MAY retain project-wide content such as skills and workflow.
+
+#### Scenario: Root file is thin and points to scoped files
+
+- **WHEN** a reader opens the root AGENTS.md
+- **THEN** they see a precedence rule, the index of scoped AGENTS.md (backend, frontend, deckdex), and project-wide sections (e.g. skills); they do not see full backend/frontend/deckdex commands or file maps in root
+
+### Requirement: Backend scoped AGENTS.md
+
+The repository SHALL contain `backend/AGENTS.md`. It MUST describe only the backend scope (API: FastAPI, routes, services, Docker). It SHALL include at least: overview, commands (install, lint, test, run) relevant to the backend, a file map for directories under `backend/`, and conventions or golden samples for backend code. It MAY reference the root AGENTS.md for project-wide skills and workflow.
+
+#### Scenario: Backend file exists and is self-contained for backend
+
+- **WHEN** a reader opens `backend/AGENTS.md`
+- **THEN** they see backend-specific commands and structure; they do not see frontend or deckdex-specific content in this file
+
+### Requirement: Frontend scoped AGENTS.md
+
+The repository SHALL contain `frontend/AGENTS.md`. It MUST describe only the frontend scope (React, TypeScript, Vite). It SHALL include at least: overview, commands (install, lint, test, build, dev) relevant to the frontend, a file map for directories under `frontend/`, and conventions or golden samples for frontend code. It MAY reference the root AGENTS.md for project-wide skills and workflow.
+
+#### Scenario: Frontend file exists and is self-contained for frontend
+
+- **WHEN** a reader opens `frontend/AGENTS.md`
+- **THEN** they see frontend-specific commands and structure; they do not see backend or deckdex-specific content in this file
+
+### Requirement: Deckdex scoped AGENTS.md
+
+The repository SHALL contain `deckdex/AGENTS.md`. It MUST describe only the deckdex package scope (core library/CLI: processor, storage, config). It SHALL include at least: overview, commands relevant to deckdex (if any, e.g. tests), a file map for `deckdex/` (and subpackages such as `storage/`), and conventions or golden samples for deckdex code. It MAY reference the root AGENTS.md for project-wide skills and workflow.
+
+#### Scenario: Deckdex file exists and is self-contained for deckdex
+
+- **WHEN** a reader opens `deckdex/AGENTS.md`
+- **THEN** they see deckdex-specific structure and conventions; they do not see backend or frontend-specific content in this file
+
+### Requirement: No duplication of stack content in root
+
+Root AGENTS.md SHALL NOT contain full command tables, file maps, or golden samples that are specific to backend, frontend, or deckdex. Those MUST live only in the corresponding scoped file. Root MAY contain a short file map that describes top-level directories (e.g. backend/, frontend/, deckdex/) at a single line each if that aids navigation without duplicating scoped content.
+
+#### Scenario: Root does not duplicate scoped content
+
+- **WHEN** comparing root AGENTS.md with backend/AGENTS.md, frontend/AGENTS.md, and deckdex/AGENTS.md
+- **THEN** detailed backend commands/file map are only in backend/AGENTS.md; detailed frontend commands/file map only in frontend/AGENTS.md; detailed deckdex file map/conventions only in deckdex/AGENTS.md

--- a/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/tasks.md
+++ b/openspec/changes/archive/2026-02-08-agents-optimization-by-profile/tasks.md
@@ -1,0 +1,11 @@
+## 1. Scoped AGENTS.md files
+
+- [x] 1.1 Create `backend/AGENTS.md` with overview, commands, file map, and conventions for the API (FastAPI)
+- [x] 1.2 Create `frontend/AGENTS.md` with overview, commands, file map, and conventions for the web app (React, TypeScript, Vite)
+- [x] 1.3 Create `deckdex/AGENTS.md` with overview, file map, and conventions for the core package (processor, storage, config)
+
+## 2. Root AGENTS.md refactor
+
+- [x] 2.1 Add precedence rule at the top of root AGENTS.md ("closest AGENTS.md wins; root holds global defaults only")
+- [x] 2.2 Add "Index of scoped AGENTS.md" section listing backend, frontend, and deckdex with brief descriptions
+- [x] 2.3 Ensure root does not duplicate stack-specific content (commands, file maps, golden samples); keep skills and workflow

--- a/openspec/specs/agent-documentation-scoped/spec.md
+++ b/openspec/specs/agent-documentation-scoped/spec.md
@@ -1,0 +1,46 @@
+## Requirements
+
+### Requirement: Thin root AGENTS.md with precedence and index
+
+The repository root SHALL contain a single `AGENTS.md` that is kept thin. It MUST state the precedence rule (e.g. "the closest AGENTS.md to the files you are changing wins; root holds global defaults only"). It MUST include an "Index of scoped AGENTS.md" section that lists exactly the scoped files: `backend/AGENTS.md`, `frontend/AGENTS.md`, and `deckdex/AGENTS.md`, each with a brief description of the scope. Root SHALL NOT duplicate stack-specific content (commands, file maps, golden samples) that belong in scoped files; it MAY retain project-wide content such as skills and workflow.
+
+#### Scenario: Root file is thin and points to scoped files
+
+- **WHEN** a reader opens the root AGENTS.md
+- **THEN** they see a precedence rule, the index of scoped AGENTS.md (backend, frontend, deckdex), and project-wide sections (e.g. skills); they do not see full backend/frontend/deckdex commands or file maps in root
+
+### Requirement: Backend scoped AGENTS.md
+
+The repository SHALL contain `backend/AGENTS.md`. It MUST describe only the backend scope (API: FastAPI, routes, services, Docker). It SHALL include at least: overview, commands (install, lint, test, run) relevant to the backend, a file map for directories under `backend/`, and conventions or golden samples for backend code. It MAY reference the root AGENTS.md for project-wide skills and workflow.
+
+#### Scenario: Backend file exists and is self-contained for backend
+
+- **WHEN** a reader opens `backend/AGENTS.md`
+- **THEN** they see backend-specific commands and structure; they do not see frontend or deckdex-specific content in this file
+
+### Requirement: Frontend scoped AGENTS.md
+
+The repository SHALL contain `frontend/AGENTS.md`. It MUST describe only the frontend scope (React, TypeScript, Vite). It SHALL include at least: overview, commands (install, lint, test, build, dev) relevant to the frontend, a file map for directories under `frontend/`, and conventions or golden samples for frontend code. It MAY reference the root AGENTS.md for project-wide skills and workflow.
+
+#### Scenario: Frontend file exists and is self-contained for frontend
+
+- **WHEN** a reader opens `frontend/AGENTS.md`
+- **THEN** they see frontend-specific commands and structure; they do not see backend or deckdex-specific content in this file
+
+### Requirement: Deckdex scoped AGENTS.md
+
+The repository SHALL contain `deckdex/AGENTS.md`. It MUST describe only the deckdex package scope (core library/CLI: processor, storage, config). It SHALL include at least: overview, commands relevant to deckdex (if any, e.g. tests), a file map for `deckdex/` (and subpackages such as `storage/`), and conventions or golden samples for deckdex code. It MAY reference the root AGENTS.md for project-wide skills and workflow.
+
+#### Scenario: Deckdex file exists and is self-contained for deckdex
+
+- **WHEN** a reader opens `deckdex/AGENTS.md`
+- **THEN** they see deckdex-specific structure and conventions; they do not see backend or frontend-specific content in this file
+
+### Requirement: No duplication of stack content in root
+
+Root AGENTS.md SHALL NOT contain full command tables, file maps, or golden samples that are specific to backend, frontend, or deckdex. Those MUST live only in the corresponding scoped file. Root MAY contain a short file map that describes top-level directories (e.g. backend/, frontend/, deckdex/) at a single line each if that aids navigation without duplicating scoped content.
+
+#### Scenario: Root does not duplicate scoped content
+
+- **WHEN** comparing root AGENTS.md with backend/AGENTS.md, frontend/AGENTS.md, and deckdex/AGENTS.md
+- **THEN** detailed backend commands/file map are only in backend/AGENTS.md; detailed frontend commands/file map only in frontend/AGENTS.md; detailed deckdex file map/conventions only in deckdex/AGENTS.md


### PR DESCRIPTION
- Root: precedence rule and index of scoped AGENTS.md
- backend/AGENTS.md, frontend/AGENTS.md, deckdex/AGENTS.md
- Archive agents-optimization-by-profile; sync spec to main