### PR TITLE
feat(web): card detail modal on row click and on-demand Scryfall image

### DIFF
--- a/backend/api/services/card_image_service.py
+++ b/backend/api/services/card_image_service.py
@@ -1,0 +1,105 @@
+"""
+Card image service: resolve card image by id, with on-demand fetch from Scryfall and filesystem storage.
+"""
+import os
+import sys
+from pathlib import Path
+from typing import Tuple
+
+# Project root for default data path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import requests
+from loguru import logger
+
+from deckdex.config_loader import load_config
+from deckdex.card_fetcher import CardFetcher
+
+
+# Directory for stored card images (default: data/card_images under project root)
+def _images_dir() -> Path:
+    raw = os.getenv("DECKDEX_CARD_IMAGES_DIR", "").strip()
+    if raw:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = project_root / path
+    else:
+        path = Path(project_root) / "data" / "card_images"
+    return path
+
+
+def ensure_images_dir() -> Path:
+    """Create card images directory if it does not exist. Return the path."""
+    d = _images_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def get_card_image(card_id: int) -> Tuple[bytes, str]:
+    """
+    Return (image_bytes, content_type) for the given card id.
+    If image is already stored, read from filesystem; otherwise fetch from Scryfall, store, then return.
+    Raises FileNotFoundError if card not found or image unavailable.
+    """
+    from ..dependencies import get_collection_repo
+
+    repo = get_collection_repo()
+    if repo is None:
+        raise FileNotFoundError("Card images require PostgreSQL (DATABASE_URL)")
+
+    card = repo.get_card_by_id(card_id)
+    if not card:
+        raise FileNotFoundError(f"Card id {card_id} not found")
+
+    name = (card.get("name") or "").strip()
+    if not name:
+        raise FileNotFoundError(f"Card id {card_id} has no name")
+
+    images_dir = ensure_images_dir()
+    path = images_dir / f"{card_id}.jpg"
+
+    if path.exists():
+        try:
+            data = path.read_bytes()
+            return data, "image/jpeg"
+        except Exception as e:
+            logger.warning(f"Failed to read stored image {path}: {e}")
+            # Fall through to re-fetch
+
+    config = load_config(profile=os.getenv("DECKDEX_PROFILE", "default"))
+    fetcher = CardFetcher(config.scryfall, config.openai)
+
+    try:
+        scryfall_card = fetcher.search_card(name)
+    except Exception as e:
+        logger.warning(f"Scryfall lookup failed for '{name}': {e}")
+        raise FileNotFoundError(f"Could not fetch image for card '{name}'") from e
+
+    # Single-faced: image_uris at top level; double-faced: use first face
+    image_uris = None
+    if "card_faces" in scryfall_card and scryfall_card["card_faces"]:
+        first_face = scryfall_card["card_faces"][0]
+        image_uris = first_face.get("image_uris") if isinstance(first_face, dict) else None
+    if not image_uris:
+        image_uris = scryfall_card.get("image_uris") or {}
+    image_url = image_uris.get("normal") or image_uris.get("large")
+    if not image_url:
+        raise FileNotFoundError(f"No image URL for card '{name}'")
+
+    try:
+        resp = requests.get(image_url, timeout=config.scryfall.timeout)
+        resp.raise_for_status()
+        data = resp.content
+    except Exception as e:
+        logger.warning(f"Failed to download image from Scryfall: {e}")
+        raise FileNotFoundError(f"Could not download image for '{name}'") from e
+
+    try:
+        path.write_bytes(data)
+    except Exception as e:
+        logger.warning(f"Failed to write image to {path}: {e}")
+        # Still return the bytes
+
+    return data, "image/jpeg"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -90,6 +90,9 @@ export const api = {
     return response.json();
   },
 
+  /** URL for card image by id (use as img src). Backend fetches from Scryfall on first request and caches. */
+  getCardImageUrl: (id: number): string => `${API_BASE}/cards/${id}/image`,
+
   // Stats
   getStats: async (): Promise<Stats> => {
     const response = await apiFetch(`${API_BASE}/stats/`);

--- a/frontend/src/components/CardDetailModal.tsx
+++ b/frontend/src/components/CardDetailModal.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { Card, api } from '../api/client';
+
+interface CardDetailModalProps {
+  card: Card;
+  onClose: () => void;
+}
+
+export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const hasId = card.id != null;
+  const imageUrl = hasId ? api.getCardImageUrl(card.id) : null;
+
+  const pt = [card.power, card.toughness].filter(Boolean).join('/');
+  const priceStr = card.price && card.price !== 'N/A' ? `€${card.price}` : 'N/A';
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col md:flex-row"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Left: image */}
+        <div className="relative flex-shrink-0 p-4 flex items-center justify-center bg-gray-100 dark:bg-gray-900 min-h-[200px] md:min-w-[280px]">
+          {imageUrl ? (
+            <>
+              {!imageLoaded && !imageError && (
+                <div className="absolute w-[244px] h-[340px] rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" aria-hidden />
+              )}
+              {imageError && (
+                <div className="text-center text-gray-500 dark:text-gray-400 text-sm p-4">
+                  Image unavailable
+                </div>
+              )}
+              <img
+                src={imageUrl}
+                alt={card.name || 'Card'}
+                className={`max-w-[244px] max-h-[340px] w-auto h-auto object-contain rounded-lg shadow-md ${!imageLoaded && !imageError ? 'invisible' : ''}`}
+                onLoad={() => { setImageLoaded(true); setImageError(false); }}
+                onError={() => setImageError(true)}
+              />
+            </>
+          ) : (
+            <div className="text-center text-gray-500 dark:text-gray-400 text-sm p-4">
+              Image not available
+            </div>
+          )}
+        </div>
+
+        {/* Right: structured text (Scryfall-like) */}
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="flex justify-between items-start gap-2 mb-4">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white leading-tight">
+              {card.name || 'Unknown'}
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-shrink-0 p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-300"
+              aria-label="Close"
+            >
+              <span className="text-xl leading-none">×</span>
+            </button>
+          </div>
+
+          {(card.mana_cost || card.type) && (
+            <div className="flex flex-wrap items-center gap-2 mb-2 text-gray-700 dark:text-gray-300">
+              {card.mana_cost && (
+                <span className="font-mono text-sm">{card.mana_cost}</span>
+              )}
+              {card.type && (
+                <span className="text-sm italic">{card.type}</span>
+              )}
+            </div>
+          )}
+
+          {card.description && (
+            <div className="mb-4">
+              <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap leading-relaxed">
+                {card.description}
+              </p>
+            </div>
+          )}
+
+          {(card.power || card.toughness) && (
+            <div className="mb-4 text-sm font-medium text-gray-700 dark:text-gray-300">
+              {pt}
+            </div>
+          )}
+
+          <div className="space-y-1 text-sm text-gray-600 dark:text-gray-400 border-t border-gray-200 dark:border-gray-600 pt-4 mt-4">
+            {card.set_name && (
+              <p><span className="font-medium text-gray-700 dark:text-gray-300">Set:</span> {card.set_name}{card.number ? ` #${card.number}` : ''}</p>
+            )}
+            {card.rarity && (
+              <p><span className="font-medium text-gray-700 dark:text-gray-300">Rarity:</span> {card.rarity}</p>
+            )}
+            <p><span className="font-medium text-gray-700 dark:text-gray-300">Price:</span> {priceStr}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CardTable.tsx
+++ b/frontend/src/components/CardTable.tsx
@@ -7,9 +7,10 @@ interface CardTableProps {
   onAdd?: () => void;
   onEdit?: (card: Card) => void;
   onDelete?: (card: Card) => void;
+  onRowClick?: (card: Card) => void;
 }
 
-export function CardTable({ cards, isLoading, onAdd, onEdit, onDelete }: CardTableProps) {
+export function CardTable({ cards, isLoading, onAdd, onEdit, onDelete, onRowClick }: CardTableProps) {
   const hasIds = cards.some(c => c.id != null);
   const [sortKey, setSortKey] = useState<string>('name');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
@@ -107,7 +108,11 @@ export function CardTable({ cards, isLoading, onAdd, onEdit, onDelete }: CardTab
           </thead>
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-600">
             {paginatedCards.map((card, index) => (
-              <tr key={card.id ?? index} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <tr
+                key={card.id ?? index}
+                className={`hover:bg-gray-50 dark:hover:bg-gray-700/50 ${onRowClick ? 'cursor-pointer' : ''}`}
+                onClick={() => onRowClick?.(card)}
+              >
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                   {card.name}
                 </td>
@@ -131,14 +136,14 @@ export function CardTable({ cards, isLoading, onAdd, onEdit, onDelete }: CardTab
                   {card.set_name || 'N/A'}
                 </td>
                 {hasIds && (onEdit || onDelete) && (
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-right" onClick={e => e.stopPropagation()}>
                     {onEdit && card.id != null && (
-                      <button type="button" onClick={() => onEdit(card)} className="text-blue-600 dark:text-blue-400 hover:underline mr-2">
+                      <button type="button" onClick={(e) => { e.stopPropagation(); onEdit(card); }} className="text-blue-600 dark:text-blue-400 hover:underline mr-2">
                         Edit
                       </button>
                     )}
                     {onDelete && card.id != null && (
-                      <button type="button" onClick={() => onDelete(card)} className="text-red-600 dark:text-red-400 hover:underline">
+                      <button type="button" onClick={(e) => { e.stopPropagation(); onDelete(card); }} className="text-red-600 dark:text-red-400 hover:underline">
                         Delete
                       </button>
                     )}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import { StatsCards } from '../components/StatsCards';
 import { Filters } from '../components/Filters';
 import { CardTable } from '../components/CardTable';
 import { CardFormModal } from '../components/CardFormModal';
+import { CardDetailModal } from '../components/CardDetailModal';
 import { ActionButtons } from '../components/ActionButtons';
 import { ActiveJobs } from '../components/ActiveJobs';
 import { ThemeToggle } from '../components/ThemeToggle';
@@ -27,6 +28,7 @@ export function Dashboard() {
   const [priceMax, setPriceMax] = useState('');
   const [backgroundJobs, setBackgroundJobs] = useState<JobInfo[]>([]);
   const [cardModal, setCardModal] = useState<null | 'add' | { card: Card }>(null);
+  const [detailCard, setDetailCard] = useState<Card | null>(null);
 
   // Fetch cards with filters
   const { data: cards, isLoading, error } = useCards({
@@ -79,6 +81,7 @@ export function Dashboard() {
 
   const handleAddCard = useCallback(() => setCardModal('add'), []);
   const handleEditCard = useCallback((card: Card) => setCardModal({ card }), []);
+  const handleRowClick = useCallback((card: Card) => setDetailCard(card), []);
   const handleDeleteCard = useCallback(async (card: Card) => {
     if (card.id == null) return;
     if (!window.confirm(`Delete "${card.name}"?`)) return;
@@ -275,6 +278,7 @@ uvicorn api.main:app --reload --port 8000
           onAdd={handleAddCard}
           onEdit={handleEditCard}
           onDelete={handleDeleteCard}
+          onRowClick={handleRowClick}
         />
       </div>
 
@@ -284,6 +288,13 @@ uvicorn api.main:app --reload --port 8000
           initial={cardModal === 'add' ? undefined : cardModal.card}
           onSubmit={handleCardSubmit}
           onClose={() => setCardModal(null)}
+        />
+      )}
+
+      {detailCard && (
+        <CardDetailModal
+          card={detailCard}
+          onClose={() => setDetailCard(null)}
         />
       )}
 

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/design.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The dashboard shows a table of cards (name, type, rarity, price, set) with pagination and sort. Cards come from Postgres via GET /api/cards; each row has optional Edit/Delete. There is no way to view full card details or artwork without leaving the table. Scryfall exposes card images via `image_uris` on the card object; our `deckdex/card_fetcher` already fetches card data by name (exact then fuzzy) but does not persist or serve images. Storing every card image at import time would be costly for large collections; on-demand fetch-and-store keeps import fast and only stores images that users actually view.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make table rows clickable (except Edit/Delete) and open a read-only detail modal.
+- Show card image (from backend) and structured card data (name, type, mana cost, oracle text, P/T, set, rarity, price) in a Scryfall-like layout.
+- Backend: resolve image by card id; if not stored, fetch from Scryfall by card name, save to filesystem, then serve; subsequent requests serve from storage.
+
+**Non-Goals:**
+
+- Editing card data from the detail modal (edit stays in existing form modal).
+- Choosing which Scryfall printing/set when multiple match the same name (first match is acceptable for v1).
+- Double-faced card UI (show one face only for v1; backend can use first face’s image).
+- Image format selection (e.g. normal vs large); use one format consistently (e.g. `normal` or `large`).
+
+## Decisions
+
+### 1. Where to store card images
+
+- **Decision:** Store images on the **filesystem** under a dedicated directory (e.g. `data/card_images/`), one file per card id (e.g. `{id}.jpg`).
+- **Rationale:** No schema change, simple to implement, easy to serve (read file and stream). Backup/restore can include the directory. If we need to move to object storage or DB later, the API contract (GET by id) stays the same.
+- **Alternatives considered:** Table with BLOB or path column (adds migration and complexity); object storage (overkill for single-server v1).
+
+### 2. Image endpoint and route order
+
+- **Decision:** Add GET `/api/cards/{id}/image` where `id` is the surrogate card id (integer). Register this route so it is matched for path `/api/cards/{id}/image` and does not conflict with GET `/api/cards/{card_id_or_name}` (e.g. mount image route with a more specific path or define `/image` sub-path).
+- **Rationale:** RESTful and clear: “card resource’s image”. Frontend can request image with card id it already has from the list/detail.
+- **Implementation note:** In FastAPI, define the route with path `/api/cards/{id}/image` and ensure it is evaluated before the generic `/api/cards/{card_id_or_name}` (e.g. more specific route first, or use a router prefix like `/api/cards` and route `/{id}/image` before `/{card_id_or_name}`).
+
+### 3. Scryfall image URL and format
+
+- **Decision:** Use Scryfall’s `image_uris['normal']` (or `['large']`) from the card object returned by `CardFetcher.search_card(name)`. Save as JPEG (or keep extension from URL). Single-faced cards have `image_uris` at top level; double-faced: use first face’s `image_uris` for v1.
+- **Rationale:** `normal`/`large` are good for modal display; no auth required for Scryfall’s public API. Storing after download avoids repeated Scryfall requests for the same card.
+
+### 4. Frontend modal and image loading
+
+- **Decision:** New component (e.g. `CardDetailModal`) receives the selected `Card`; it displays DB fields in a fixed layout and loads the image via GET `/api/cards/{card.id}/image` (as `img` src or via fetch and blob URL). Show placeholder/skeleton while loading; on error (e.g. 404 or 5xx) show a fallback message or icon.
+- **Rationale:** Keeps modal presentational; Dashboard (or parent) owns “which card is selected” and passes it in. Using `img src="/api/cards/123/image"` is simple and benefits from browser caching.
+
+### 5. Edit/Delete vs row click
+
+- **Decision:** Row has `onClick` to open detail modal. Edit and Delete buttons call `event.stopPropagation()` so clicking them does not open the detail modal.
+- **Rationale:** Standard UX: row = view details, buttons = actions. Prevents accidental navigation when intending to edit or delete.
+
+## Risks / Trade-offs
+
+- **Scryfall rate limits:** Public API allows ~10 req/s. On-demand fetch is one request per first view per card; acceptable for typical usage. Mitigation: existing retry/backoff in CardFetcher; if we add bulk “prefetch” later, we would need to throttle.
+- **Wrong printing for duplicate names:** Same card name can have multiple printings. We do not pass set to Scryfall for v1, so the first match may not match the user’s set. Mitigation: document; future improvement could pass set_name or set_id to narrow search.
+- **Disk usage:** Images stored indefinitely. Mitigation: optional cleanup job or “delete images for deleted cards” can be added later; not required for MVP.
+- **404 on image:** Card exists but Scryfall fetch fails (e.g. name typo, API down). Mitigation: return 404 or 503 with clear behavior; modal shows error state so user knows image is unavailable.
+
+## Migration Plan
+
+- No DB migrations required (images on filesystem).
+- Deploy: ensure `data/card_images/` (or chosen path) is writable by the backend process; directory can be created on first write.
+- Rollback: remove new route and frontend modal/row click; no data migration to revert.
+
+## Open Questions
+
+- None blocking. Optional follow-ups: double-faced card both faces in modal; set-aware Scryfall lookup; cache headers for GET image (e.g. long max-age once stored).

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/proposal.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Users cannot quickly view full card details and artwork from the collection table. Downloading all card images on import would be expensive and slow; showing details and artwork on demand (on row click) improves UX and keeps storage and import cost low by fetching and persisting images only when a user opens a card.
+
+## What Changes
+
+- Table rows in the cards table become clickable (excluding clicks on Edit/Delete).
+- Clicking a row opens a read-only modal showing that card’s details in a Scryfall-style layout: card image on one side, structured text (name, type, mana cost, oracle text, P/T, set, rarity, price) on the other, using data from our database.
+- Card image is loaded on demand: backend looks up by card id; if no image is stored, it fetches the card by name from Scryfall, downloads the image, stores it (filesystem), then serves it. Subsequent views for that card use the stored image.
+- New backend endpoint: GET `/api/cards/{id}/image` returns the card image (or 404 if card missing / image unavailable after fetch attempt).
+
+## Capabilities
+
+### New Capabilities
+
+- **card-detail-modal**: Modal that displays a single card’s data (from our API) plus its image (from the image endpoint), in a Scryfall-like layout (image left, text right). Handles loading and error states.
+- **card-image-storage**: Backend behavior to resolve card image by id: return stored image if present; otherwise fetch card by name via Scryfall, download image, persist to filesystem, then serve. Includes the GET endpoint contract and storage location.
+
+### Modified Capabilities
+
+- **web-dashboard-ui**: Table rows are clickable to open the card detail modal; Edit/Delete buttons must not trigger row click (e.g. stopPropagation). Dashboard wires the table to the new modal and image API.
+- **web-api-backend**: New requirement to provide GET `/api/cards/{id}/image` that returns the card’s image (by id), with on-demand fetch-from-Scryfall-and-store when not yet stored.
+
+## Impact
+
+- **Frontend:** `CardTable.tsx` (row click, optional callback), new `CardDetailModal` (or equivalent), `Dashboard.tsx` (state and wiring). API client: new method for GET card image.
+- **Backend:** New route under cards (e.g. `/api/cards/{id}/image`), use of existing `CardFetcher` (Scryfall) and collection repo to get card name by id; new filesystem directory for stored images (e.g. `data/card_images/`).
+- **Dependencies:** No new external dependencies; Scryfall public API and existing `deckdex/card_fetcher` are sufficient for image URLs.

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/specs/card-detail-modal/spec.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/specs/card-detail-modal/spec.md
@@ -1,0 +1,27 @@
+# Card Detail Modal
+
+Read-only modal that displays a single card's data (from the collection API) and its image (from the card image endpoint) in a Scryfall-style layout: image on one side, structured text on the other. Used when the user clicks a row in the card table.
+
+### Requirement: Card detail modal SHALL display card image and structured data
+
+The system SHALL provide a modal component that shows the selected card's image and metadata in a fixed layout. The image SHALL be loaded from the backend card image endpoint (by card id). The text content SHALL use data from the application's card model (name, type line, mana cost, description/oracle text, power/toughness, set name, set number, rarity, price) in a structured, Scryfall-like presentation (e.g. image left, text right).
+
+#### Scenario: Modal shows card image from image endpoint
+- **WHEN** the modal is open with a card that has an id
+- **THEN** the system requests the card image from the backend (e.g. GET `/api/cards/{id}/image`) and displays it in the modal
+
+#### Scenario: Modal shows loading state while image loads
+- **WHEN** the image request is in progress
+- **THEN** the modal displays a placeholder or skeleton where the image will appear (e.g. loading spinner or gray block)
+
+#### Scenario: Modal shows error state when image unavailable
+- **WHEN** the image endpoint returns an error (e.g. 404 or 5xx)
+- **THEN** the modal displays a fallback (e.g. message or icon) indicating the image is unavailable, and still shows the card's text data
+
+#### Scenario: Modal displays structured card text
+- **WHEN** the modal is open with a card
+- **THEN** the system displays at least: name, type line, mana cost, description (oracle text), power/toughness when present, set name, set number, rarity, and price in a clear layout consistent with a Scryfall-style card view
+
+#### Scenario: Modal can be closed
+- **WHEN** the user closes the modal (e.g. close button or overlay click)
+- **THEN** the modal is dismissed and focus returns to the dashboard; no data is persisted from the modal (read-only)

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/specs/card-image-storage/spec.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/specs/card-image-storage/spec.md
@@ -1,0 +1,23 @@
+# Card Image Storage
+
+Backend behavior to resolve a card's image by surrogate card id: return stored image if present; otherwise fetch the card by name from Scryfall, download the image, persist it to the filesystem, then serve it. Defines the GET endpoint contract and storage semantics.
+
+### Requirement: Backend SHALL provide card image endpoint by card id
+
+The system SHALL expose GET `/api/cards/{id}/image` where `id` is the surrogate card id (integer). The response SHALL be the card's image (e.g. image/jpeg or image/png). If no image is stored for that card, the system SHALL attempt to fetch the card by name from Scryfall, download the image, store it, then return it. If the card does not exist or the image cannot be obtained, the system SHALL return an appropriate error (e.g. 404).
+
+#### Scenario: Return stored image when available
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and an image is already stored for that card id
+- **THEN** system returns the stored image with appropriate Content-Type (e.g. image/jpeg) and status 200
+
+#### Scenario: Fetch from Scryfall and store when not stored
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and no image is stored for that card id
+- **THEN** system looks up the card by id to get its name, fetches the card from Scryfall by name, obtains the image URL (e.g. from image_uris), downloads the image, stores it in the configured storage (e.g. filesystem), and returns the image with status 200
+
+#### Scenario: Return 404 when card not found
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and no card exists with that id
+- **THEN** system returns 404 (or 404 when image cannot be obtained after a valid card lookup, per product choice)
+
+#### Scenario: Images persist for subsequent requests
+- **WHEN** an image was stored in a previous request for a given card id
+- **THEN** subsequent GET requests to `/api/cards/{id}/image` for that id return the stored image without calling Scryfall again

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/specs/web-api-backend/spec.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/specs/web-api-backend/spec.md
@@ -1,0 +1,19 @@
+# Web API Backend (delta)
+
+## ADDED Requirements
+
+### Requirement: Backend SHALL provide card image endpoint
+
+The system SHALL provide GET `/api/cards/{id}/image` where `id` is the surrogate card id (integer). The endpoint SHALL return the card's image (binary, with appropriate image Content-Type). If the image is not stored, the system SHALL fetch the card by name from Scryfall, download the image, persist it (e.g. to filesystem), and then serve it. The system SHALL return 404 when the card does not exist or the image cannot be obtained.
+
+#### Scenario: GET card image by id returns image when available
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and the card exists and has a stored image (or image is successfully fetched and stored)
+- **THEN** system responds with status 200 and body containing the image bytes with appropriate Content-Type (e.g. image/jpeg)
+
+#### Scenario: GET card image returns 404 when card not found
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and no card exists with that id
+- **THEN** system responds with status 404
+
+#### Scenario: Card image route does not conflict with get card by name
+- **WHEN** client sends GET request to `/api/cards/123/image`
+- **THEN** system treats this as a request for the image of card with id 123, not as a request for a card with name "123" or "123/image"

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/specs/web-dashboard-ui/spec.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/specs/web-dashboard-ui/spec.md
@@ -1,0 +1,23 @@
+# Web Dashboard UI (delta)
+
+## ADDED Requirements
+
+### Requirement: Card table rows SHALL be clickable to open card detail modal
+
+The system SHALL allow the user to click on a card table row to open a read-only card detail modal. Clicks on row actions (Edit, Delete) SHALL NOT open the detail modal; only clicking the row itself SHALL trigger opening the modal.
+
+#### Scenario: Clicking a row opens card detail modal
+- **WHEN** the user clicks on a card row in the table (and not on Edit or Delete)
+- **THEN** the system opens the card detail modal with that card's data and loads its image
+
+#### Scenario: Clicking Edit does not open detail modal
+- **WHEN** the user clicks the Edit button on a row
+- **THEN** the system performs the edit action (e.g. opens edit form) and does NOT open the card detail modal
+
+#### Scenario: Clicking Delete does not open detail modal
+- **WHEN** the user clicks the Delete button on a row
+- **THEN** the system performs the delete action and does NOT open the card detail modal
+
+#### Scenario: Dashboard wires table to card detail modal
+- **WHEN** the dashboard renders the card table
+- **THEN** the table is configured with a row-click handler that opens the card detail modal for the clicked card, and the modal receives the selected card and uses the image API for that card's id

--- a/openspec/changes/archive/2026-02-08-card-details-on-click/tasks.md
+++ b/openspec/changes/archive/2026-02-08-card-details-on-click/tasks.md
@@ -1,0 +1,18 @@
+## 1. Backend – card image storage and endpoint
+
+- [x] 1.1 Define filesystem path for card images (e.g. `data/card_images/`) and ensure directory is created on first write (or at app startup)
+- [x] 1.2 Implement helper: given card id, check if image file exists; if not, get card by id from repo (name), call CardFetcher.search_card(name), get image URL from image_uris (normal or large), download image, save to `{images_dir}/{id}.jpg` (or appropriate extension), return file path or bytes
+- [x] 1.3 Add GET `/api/cards/{id}/image` route that returns image for card id (use helper); return 404 if card not found or image unavailable; ensure route is matched before generic GET `/api/cards/{card_id_or_name}` (e.g. register more specific path first)
+- [x] 1.4 Handle double-faced cards: use first face's image_uris when card has card_faces
+
+## 2. Frontend – API client and card detail modal
+
+- [x] 2.1 Add API client method to get card image URL or blob for a card id (e.g. `getCardImageUrl(id)` returning URL string for use in `img` src, or equivalent)
+- [x] 2.2 Create CardDetailModal component: accepts card (Card), onClose callback; layout: image area (left) and text block (right); request image via GET `/api/cards/{card.id}/image` (e.g. as img src); show loading state while image loads; show fallback (message/icon) on image error; display name, type_line, mana_cost, description, power, toughness, set_name, set_number, rarity, price from card
+- [x] 2.3 Style modal for Scryfall-like presentation (image + structured text), responsive; close on overlay click and via close button
+
+## 3. Frontend – table row click and dashboard wiring
+
+- [x] 3.1 CardTable: add optional prop `onRowClick?: (card: Card) => void`; on each `<tr>`, add onClick that calls `onRowClick?.(card)`; on Edit and Delete buttons, add `onClick={e => e.stopPropagation()}` so row click does not fire
+- [x] 3.2 Dashboard: add state for selected card for detail view (e.g. `detailCard: Card | null`); when `onRowClick(card)` is called, set selected card and show CardDetailModal; when modal closes, clear selected card
+- [x] 3.3 Pass `onRowClick` from Dashboard to CardTable; render CardDetailModal when detailCard is set, passing card and onClose

--- a/openspec/specs/card-detail-modal/spec.md
+++ b/openspec/specs/card-detail-modal/spec.md
@@ -1,0 +1,27 @@
+# Card Detail Modal
+
+Read-only modal that displays a single card's data (from the collection API) and its image (from the card image endpoint) in a Scryfall-style layout: image on one side, structured text on the other. Used when the user clicks a row in the card table.
+
+### Requirement: Card detail modal SHALL display card image and structured data
+
+The system SHALL provide a modal component that shows the selected card's image and metadata in a fixed layout. The image SHALL be loaded from the backend card image endpoint (by card id). The text content SHALL use data from the application's card model (name, type line, mana cost, description/oracle text, power/toughness, set name, set number, rarity, price) in a structured, Scryfall-like presentation (e.g. image left, text right).
+
+#### Scenario: Modal shows card image from image endpoint
+- **WHEN** the modal is open with a card that has an id
+- **THEN** the system requests the card image from the backend (e.g. GET `/api/cards/{id}/image`) and displays it in the modal
+
+#### Scenario: Modal shows loading state while image loads
+- **WHEN** the image request is in progress
+- **THEN** the modal displays a placeholder or skeleton where the image will appear (e.g. loading spinner or gray block)
+
+#### Scenario: Modal shows error state when image unavailable
+- **WHEN** the image endpoint returns an error (e.g. 404 or 5xx)
+- **THEN** the modal displays a fallback (e.g. message or icon) indicating the image is unavailable, and still shows the card's text data
+
+#### Scenario: Modal displays structured card text
+- **WHEN** the modal is open with a card
+- **THEN** the system displays at least: name, type line, mana cost, description (oracle text), power/toughness when present, set name, set number, rarity, and price in a clear layout consistent with a Scryfall-style card view
+
+#### Scenario: Modal can be closed
+- **WHEN** the user closes the modal (e.g. close button or overlay click)
+- **THEN** the modal is dismissed and focus returns to the dashboard; no data is persisted from the modal (read-only)

--- a/openspec/specs/card-image-storage/spec.md
+++ b/openspec/specs/card-image-storage/spec.md
@@ -1,0 +1,23 @@
+# Card Image Storage
+
+Backend behavior to resolve a card's image by surrogate card id: return stored image if present; otherwise fetch the card by name from Scryfall, download the image, persist it to the filesystem, then serve it. Defines the GET endpoint contract and storage semantics.
+
+### Requirement: Backend SHALL provide card image endpoint by card id
+
+The system SHALL expose GET `/api/cards/{id}/image` where `id` is the surrogate card id (integer). The response SHALL be the card's image (e.g. image/jpeg or image/png). If no image is stored for that card, the system SHALL attempt to fetch the card by name from Scryfall, download the image, store it, then return it. If the card does not exist or the image cannot be obtained, the system SHALL return an appropriate error (e.g. 404).
+
+#### Scenario: Return stored image when available
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and an image is already stored for that card id
+- **THEN** system returns the stored image with appropriate Content-Type (e.g. image/jpeg) and status 200
+
+#### Scenario: Fetch from Scryfall and store when not stored
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and no image is stored for that card id
+- **THEN** system looks up the card by id to get its name, fetches the card from Scryfall by name, obtains the image URL (e.g. from image_uris), downloads the image, stores it in the configured storage (e.g. filesystem), and returns the image with status 200
+
+#### Scenario: Return 404 when card not found
+- **WHEN** client sends GET request to `/api/cards/{id}/image` and no card exists with that id
+- **THEN** system returns 404 (or 404 when image cannot be obtained after a valid card lookup, per product choice)
+
+#### Scenario: Images persist for subsequent requests
+- **WHEN** an image was stored in a previous request for a given card id
+- **THEN** subsequent GET requests to `/api/cards/{id}/image` for that id return the stored image without calling Scryfall again

--- a/openspec/specs/web-dashboard-ui/spec.md
+++ b/openspec/specs/web-dashboard-ui/spec.md
@@ -1,6 +1,6 @@
 # Web Dashboard UI
 
-React (Vite, port 5173). **Overview:** 2-column grid: Total Cards, Total Value (subtitle Avg: €X.XX); 30s auto-refresh; skeleton loaders. No price chart in MVP (no history DB). **Table:** 50 cards/page; name, type, rarity, price, set; pagination; sort by column. **Filters:** search by name; by rarity, type, set, price range (min/max); active filters as removable chips; result count (e.g. "Showing X cards"); Clear Filters. **Jobs:** On mount GET /api/jobs → restore backgroundJobs. Buttons: Process Cards, Update Prices → POST, open progress modal; disable when running. **Progress modal:** 0% "Connecting…"; WebSocket → update bar and "Processing X/Y"; errors in scrollable list; complete → summary (processed, success, errors, duration); Done → close and refetch. Stop → POST cancel, "Stopping…", orange bar; cancelled → "Process cancelled — progress X/Y (Z%)". Minimize + Stop side by side; elapsed timer in header (12s / 2m 34s / 1h 5m). On reopen: GET /api/jobs/{id} for initial state (no 0% flash); if already complete → show result without WebSocket. **WebSocket:** Reconnect up to 3× backoff; "Reconnecting…"; failure → "Connection lost" + Refresh (REST). **Styling:** Tailwind v4 (@tailwindcss/postcss, @import "tailwindcss"); bg-black/50 not bg-opacity-*; responsive grid. **Data:** TanStack Query (cache, isLoading, error + retry). **Errors:** Toast on API failure (5s); process errors → count + CSV link. **Access:** localhost:5173; backend down → friendly error + retry; ErrorBoundary for render errors. **Bottom bar:** Fixed bottom when jobs exist; list jobs vertically; completed → show 5s then remove; cancelled → orange + "Cancelled"; poll GET /api/jobs/{id} every 2s. Modern browsers.
+React (Vite, port 5173). **Overview:** 2-column grid: Total Cards, Total Value (subtitle Avg: €X.XX); 30s auto-refresh; skeleton loaders. No price chart in MVP (no history DB). **Table:** 50 cards/page; name, type, rarity, price, set; pagination; sort by column. Rows clickable to open card detail modal (image + data); Edit/Delete do not open detail modal. **Filters:** search by name; by rarity, type, set, price range (min/max); active filters as removable chips; result count (e.g. "Showing X cards"); Clear Filters. **Jobs:** On mount GET /api/jobs → restore backgroundJobs. Buttons: Process Cards, Update Prices → POST, open progress modal; disable when running. **Progress modal:** 0% "Connecting…"; WebSocket → update bar and "Processing X/Y"; errors in scrollable list; complete → summary (processed, success, errors, duration); Done → close and refetch. Stop → POST cancel, "Stopping…", orange bar; cancelled → "Process cancelled — progress X/Y (Z%)". Minimize + Stop side by side; elapsed timer in header (12s / 2m 34s / 1h 5m). On reopen: GET /api/jobs/{id} for initial state (no 0% flash); if already complete → show result without WebSocket. **WebSocket:** Reconnect up to 3× backoff; "Reconnecting…"; failure → "Connection lost" + Refresh (REST). **Styling:** Tailwind v4 (@tailwindcss/postcss, @import "tailwindcss"); bg-black/50 not bg-opacity-*; responsive grid. **Data:** TanStack Query (cache, isLoading, error + retry). **Errors:** Toast on API failure (5s); process errors → count + CSV link. **Access:** localhost:5173; backend down → friendly error + retry; ErrorBoundary for render errors. **Bottom bar:** Fixed bottom when jobs exist; list jobs vertically; completed → show 5s then remove; cancelled → orange + "Cancelled"; poll GET /api/jobs/{id} every 2s. Modern browsers.
 
 ### Requirement: Dashboard SHALL display collection overview
 
@@ -149,3 +149,23 @@ Each job entry in the bottom jobs bar SHALL provide a control (e.g. button or li
 #### Scenario: Modal can be closed
 - **WHEN** the user closes the modal (e.g. close button or overlay click)
 - **THEN** the modal is dismissed and the user returns to the dashboard view; the job continues in the bar as before
+
+### Requirement: Card table rows SHALL be clickable to open card detail modal
+
+The system SHALL allow the user to click on a card table row to open a read-only card detail modal. Clicks on row actions (Edit, Delete) SHALL NOT open the detail modal; only clicking the row itself SHALL trigger opening the modal.
+
+#### Scenario: Clicking a row opens card detail modal
+- **WHEN** the user clicks on a card row in the table (and not on Edit or Delete)
+- **THEN** the system opens the card detail modal with that card's data and loads its image
+
+#### Scenario: Clicking Edit does not open detail modal
+- **WHEN** the user clicks the Edit button on a row
+- **THEN** the system performs the edit action (e.g. opens edit form) and does NOT open the card detail modal
+
+#### Scenario: Clicking Delete does not open detail modal
+- **WHEN** the user clicks the Delete button on a row
+- **THEN** the system performs the delete action and does NOT open the card detail modal
+
+#### Scenario: Dashboard wires table to card detail modal
+- **WHEN** the dashboard renders the card table
+- **THEN** the table is configured with a row-click handler that opens the card detail modal for the clicked card, and the modal receives the selected card and uses the image API for that card's id


### PR DESCRIPTION
- Backend: GET /api/cards/{id}/image, fetch from Scryfall and store on disk
- Frontend: clickable table rows, CardDetailModal with image and structured data
- OpenSpec: archive card-details-on-click, sync specs (card-detail-modal, card-image-storage, web-dashboard-ui, web-api-backend)