### PR TITLE
feat(web): add card name autocomplete in Add card modal

### DIFF
--- a/backend/api/services/scryfall_service.py
+++ b/backend/api/services/scryfall_service.py
@@ -1,0 +1,86 @@
+"""
+Scryfall service: card name suggestions (autocomplete) and resolve card by name for Add card flow.
+"""
+import os
+import sys
+from typing import List, Dict, Any
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from loguru import logger
+
+from deckdex.config_loader import load_config
+from deckdex.card_fetcher import CardFetcher
+
+
+def _get_fetcher() -> CardFetcher:
+    config = load_config(profile=os.getenv("DECKDEX_PROFILE", "default"))
+    return CardFetcher(config.scryfall, config.openai)
+
+
+def suggest_card_names(q: str) -> List[str]:
+    """
+    Return up to 20 card names from Scryfall autocomplete.
+    Returns empty list if q is missing, too short, or on error.
+    """
+    if not q or len((q or "").strip()) < 2:
+        return []
+    try:
+        fetcher = _get_fetcher()
+        return fetcher.autocomplete(q.strip())
+    except Exception as e:
+        logger.warning(f"Scryfall suggest failed for q={q!r}: {e}")
+        return []
+
+
+class CardNotFoundError(Exception):
+    """Raised when a card name cannot be resolved from Scryfall or collection."""
+
+
+def resolve_card_by_name(name: str, from_collection: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """
+    Return full card payload (name, type, rarity, set_name, price, ...) for create.
+    If from_collection is provided and matches the name, return it. Otherwise fetch from Scryfall.
+    Raises CardNotFoundError if not found.
+    """
+    name = (name or "").strip()
+    if not name:
+        raise CardNotFoundError("Card name is empty")
+
+    if from_collection and (from_collection.get("name") or "").strip().lower() == name.lower():
+        return {k: v for k, v in from_collection.items() if v is not None}
+
+    try:
+        fetcher = _get_fetcher()
+        scryfall = fetcher.search_card(name)
+    except Exception as e:
+        logger.warning(f"Scryfall resolve failed for {name!r}: {e}")
+        raise CardNotFoundError(f"Card not found: {name}") from e
+
+    # Map Scryfall card to our card model (strings; Scryfall uses lists for colors)
+    card_type = scryfall.get("type_line") or scryfall.get("type")
+    prices = scryfall.get("prices") or {}
+    price = prices.get("eur") or prices.get("usd") or None
+    if price is not None:
+        price = str(price)
+    colors_raw = scryfall.get("colors")
+    color_identity_raw = scryfall.get("color_identity")
+    colors = ",".join(colors_raw) if isinstance(colors_raw, list) else colors_raw
+    color_identity = ",".join(color_identity_raw) if isinstance(color_identity_raw, list) else color_identity_raw
+
+    return {
+        "name": scryfall.get("name"),
+        "type": card_type,
+        "rarity": scryfall.get("rarity"),
+        "set_name": scryfall.get("set_name"),
+        "price": price,
+        "description": scryfall.get("oracle_text"),
+        "mana_cost": scryfall.get("mana_cost"),
+        "cmc": scryfall.get("cmc"),
+        "power": scryfall.get("power"),
+        "toughness": scryfall.get("toughness"),
+        "colors": colors,
+        "color_identity": color_identity,
+    }

--- a/frontend/src/components/CardDetailModal.tsx
+++ b/frontend/src/components/CardDetailModal.tsx
@@ -10,8 +10,8 @@ export function CardDetailModal({ card, onClose }: CardDetailModalProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
 
-  const hasId = card.id != null;
-  const imageUrl = hasId ? api.getCardImageUrl(card.id) : null;
+  const cardId = card.id != null ? card.id : null;
+  const imageUrl = cardId != null ? api.getCardImageUrl(cardId) : null;
 
   const pt = [card.power, card.toughness].filter(Boolean).join('/');
   const priceStr = card.price && card.price !== 'N/A' ? `€${card.price}` : 'N/A';

--- a/frontend/src/components/CardFormModal.tsx
+++ b/frontend/src/components/CardFormModal.tsx
@@ -1,14 +1,28 @@
-import { useState, useEffect } from 'react';
-import { Card } from '../api/client';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Card, api } from '../api/client';
+
+const DEBOUNCE_MS = 280;
+const MIN_QUERY_LENGTH = 2;
 
 interface CardFormModalProps {
   title: string;
+  mode: 'add' | 'edit';
   initial?: Partial<Card>;
   onSubmit: (payload: Partial<Card>) => Promise<void>;
   onClose: () => void;
 }
 
-export function CardFormModal({ title, initial, onSubmit, onClose }: CardFormModalProps) {
+type SuggestionSource = 'collection' | 'catalog';
+
+interface SuggestionItem {
+  source: SuggestionSource;
+  name: string;
+  card?: Card;
+}
+
+export function CardFormModal({ title, mode, initial, onSubmit, onClose }: CardFormModalProps) {
+  const isAdd = mode === 'add';
+
   const [name, setName] = useState(initial?.name ?? '');
   const [type, setType] = useState(initial?.type ?? '');
   const [rarity, setRarity] = useState(initial?.rarity ?? '');
@@ -16,6 +30,19 @@ export function CardFormModal({ title, initial, onSubmit, onClose }: CardFormMod
   const [setNameVal, setSetNameVal] = useState(initial?.set_name ?? '');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Add-mode: autocomplete state
+  const [query, setQuery] = useState('');
+  const [collectionCards, setCollectionCards] = useState<Card[]>([]);
+  const [catalogNames, setCatalogNames] = useState<string[]>([]);
+  const [showCatalogSection, setShowCatalogSection] = useState(false);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [selectedCardForAdd, setSelectedCardForAdd] = useState<Card | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setName(initial?.name ?? '');
@@ -25,18 +52,115 @@ export function CardFormModal({ title, initial, onSubmit, onClose }: CardFormMod
     setSetNameVal(initial?.set_name ?? '');
   }, [initial]);
 
+  // Build flat list of suggestions for keyboard nav
+  const collectionSuggestions: SuggestionItem[] = (collectionCards || []).map(c => ({
+    source: 'collection',
+    name: c.name ?? '',
+    card: c,
+  }));
+  const catalogSuggestions: SuggestionItem[] = (catalogNames || [])
+    .filter(n => !collectionSuggestions.some(s => s.name.toLowerCase() === n.toLowerCase()))
+    .map(n => ({ source: 'catalog', name: n }));
+  const allSuggestions = [...collectionSuggestions, ...catalogSuggestions];
+  const showCatalog = showCatalogSection && catalogSuggestions.length > 0;
+
+  const fetchCatalog = useCallback(async (q: string) => {
+    if (q.trim().length < MIN_QUERY_LENGTH) {
+      setCatalogNames([]);
+      return;
+    }
+    try {
+      const names = await api.getCardSuggest(q.trim());
+      setCatalogNames(names);
+    } catch {
+      setCatalogNames([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdd) return;
+    const q = query.trim();
+    setLoadingSuggestions(true);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const list = q ? await api.getCards({ search: q, limit: 10 }) : [];
+        setCollectionCards(list);
+        if (q.length >= MIN_QUERY_LENGTH && (list.length === 0 || showCatalogSection)) {
+          await fetchCatalog(q);
+        } else {
+          setCatalogNames([]);
+        }
+      } catch {
+        setCollectionCards([]);
+        setCatalogNames([]);
+      }
+      setLoadingSuggestions(false);
+      debounceRef.current = null;
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, isAdd, showCatalogSection, fetchCatalog]);
+
+  const handleSearchCatalog = useCallback(() => {
+    setShowCatalogSection(true);
+    const q = query.trim();
+    if (q.length >= MIN_QUERY_LENGTH) {
+      setLoadingSuggestions(true);
+      api.getCardSuggest(q).then(names => {
+        setCatalogNames(names);
+        setLoadingSuggestions(false);
+      }).catch(() => setLoadingSuggestions(false));
+    }
+  }, [query]);
+
+  const selectSuggestion = useCallback(async (item: SuggestionItem) => {
+    if (item.source === 'collection' && item.card) {
+      setSelectedCardForAdd(item.card);
+      setName(item.name);
+      setDropdownOpen(false);
+      setHighlightedIndex(-1);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const resolved = await api.resolveCardByName(item.name);
+      setSelectedCardForAdd(resolved);
+      setName(resolved.name ?? item.name);
+      setDropdownOpen(false);
+      setHighlightedIndex(-1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not resolve card');
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setSaving(true);
     try {
-      await onSubmit({
-        name: name.trim() || undefined,
-        type: type.trim() || undefined,
-        rarity: rarity.trim() || undefined,
-        price: price.trim() || undefined,
-        set_name: setNameVal.trim() || undefined,
-      });
+      if (isAdd && selectedCardForAdd) {
+        await onSubmit(selectedCardForAdd);
+      } else if (isAdd && name.trim()) {
+        const resolved = await api.resolveCardByName(name.trim());
+        await onSubmit(resolved);
+      } else if (!isAdd) {
+        await onSubmit({
+          name: name.trim() || undefined,
+          type: type.trim() || undefined,
+          rarity: rarity.trim() || undefined,
+          price: price.trim() || undefined,
+          set_name: setNameVal.trim() || undefined,
+        });
+      } else {
+        setError('Select a card or enter a name and try again');
+        setSaving(false);
+        return;
+      }
       onClose();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed');
@@ -45,64 +169,178 @@ export function CardFormModal({ title, initial, onSubmit, onClose }: CardFormMod
     }
   };
 
+  const onNameChange = (value: string) => {
+    setName(value);
+    if (isAdd) {
+      setQuery(value);
+      setDropdownOpen(true);
+      setSelectedCardForAdd(null);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!isAdd || !dropdownOpen) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex(i => (i < allSuggestions.length - 1 ? i + 1 : i));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex(i => (i > 0 ? i - 1 : -1));
+    } else if (e.key === 'Enter' && highlightedIndex >= 0 && allSuggestions[highlightedIndex]) {
+      e.preventDefault();
+      selectSuggestion(allSuggestions[highlightedIndex]);
+    } else if (e.key === 'Escape') {
+      setDropdownOpen(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (ev: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(ev.target as Node) && inputRef.current && !inputRef.current.contains(ev.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full mx-4 p-6" onClick={e => e.stopPropagation()}>
         <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-white">{title}</h2>
         {error && <div className="mb-4 text-red-600 dark:text-red-400 text-sm">{error}</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
+          <div ref={dropdownRef} className="relative">
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name *</label>
             <input
+              ref={inputRef}
               type="text"
               value={name}
-              onChange={e => setName(e.target.value)}
+              onChange={e => onNameChange(e.target.value)}
+              onFocus={() => isAdd && (query.trim() || allSuggestions.length > 0) && setDropdownOpen(true)}
+              onKeyDown={onKeyDown}
               className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
               required
+              autoComplete="off"
+              role="combobox"
+              aria-expanded={dropdownOpen}
+              aria-autocomplete="list"
+              aria-controls="card-suggestions-list"
+              aria-activedescendant={highlightedIndex >= 0 && allSuggestions[highlightedIndex] ? `suggestion-${highlightedIndex}` : undefined}
             />
+            {isAdd && dropdownOpen && (query.trim() || allSuggestions.length > 0) && (
+              <ul
+                id="card-suggestions-list"
+                role="listbox"
+                className="absolute z-10 left-0 right-0 mt-1 max-h-60 overflow-auto rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-lg"
+              >
+                {loadingSuggestions && allSuggestions.length === 0 && (
+                  <li className="px-3 py-2 text-gray-500 dark:text-gray-400 text-sm">Loading…</li>
+                )}
+                {collectionSuggestions.length > 0 && (
+                  <>
+                    <li className="px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-600 sticky top-0">In your collection</li>
+                    {collectionSuggestions.map((item, i) => {
+                      const idx = allSuggestions.indexOf(item);
+                      return (
+                        <li
+                          key={`c-${item.name}`}
+                          id={idx === highlightedIndex ? `suggestion-${idx}` : undefined}
+                          role="option"
+                          aria-selected={idx === highlightedIndex}
+                          className={`px-3 py-2 cursor-pointer text-gray-900 dark:text-white ${idx === highlightedIndex ? 'bg-blue-100 dark:bg-blue-900' : 'hover:bg-gray-100 dark:hover:bg-gray-600'}`}
+                          onMouseDown={e => { e.preventDefault(); selectSuggestion(item); }}
+                        >
+                          {item.name}
+                        </li>
+                      );
+                    })}
+                  </>
+                )}
+                {(showCatalog || catalogSuggestions.length > 0) && (
+                  <>
+                    <li className="px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-600 sticky top-0">Other cards</li>
+                    {catalogSuggestions.map((item, i) => {
+                      const idx = allSuggestions.indexOf(item);
+                      return (
+                        <li
+                          key={`s-${item.name}`}
+                          id={idx === highlightedIndex ? `suggestion-${idx}` : undefined}
+                          role="option"
+                          aria-selected={idx === highlightedIndex}
+                          className={`px-3 py-2 cursor-pointer text-gray-900 dark:text-white ${idx === highlightedIndex ? 'bg-blue-100 dark:bg-blue-900' : 'hover:bg-gray-100 dark:hover:bg-gray-600'}`}
+                          onMouseDown={e => { e.preventDefault(); selectSuggestion(item); }}
+                        >
+                          {item.name}
+                        </li>
+                      );
+                    })}
+                  </>
+                )}
+                {!loadingSuggestions && query.trim().length >= MIN_QUERY_LENGTH && collectionSuggestions.length > 0 && !showCatalog && (
+                  <li className="border-t border-gray-200 dark:border-gray-600">
+                    <button
+                      type="button"
+                      className="w-full text-left px-3 py-2 text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-600"
+                      onMouseDown={e => { e.preventDefault(); handleSearchCatalog(); }}
+                    >
+                      Search catalog for “{query.trim()}”
+                    </button>
+                  </li>
+                )}
+              </ul>
+            )}
           </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
-            <input
-              type="text"
-              value={type}
-              onChange={e => setType(e.target.value)}
-              className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rarity</label>
-            <input
-              type="text"
-              value={rarity}
-              onChange={e => setRarity(e.target.value)}
-              className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Price</label>
-            <input
-              type="text"
-              value={price}
-              onChange={e => setPrice(e.target.value)}
-              className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Set</label>
-            <input
-              type="text"
-              value={setNameVal}
-              onChange={e => setSetNameVal(e.target.value)}
-              className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            />
-          </div>
+
+          {!isAdd && (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+                <input
+                  type="text"
+                  value={type}
+                  onChange={e => setType(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rarity</label>
+                <input
+                  type="text"
+                  value={rarity}
+                  onChange={e => setRarity(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Price</label>
+                <input
+                  type="text"
+                  value={price}
+                  onChange={e => setPrice(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Set</label>
+                <input
+                  type="text"
+                  value={setNameVal}
+                  onChange={e => setSetNameVal(e.target.value)}
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                />
+              </div>
+            </>
+          )}
+
           <div className="flex gap-2 justify-end pt-2">
             <button type="button" onClick={onClose} className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200">
               Cancel
             </button>
             <button type="submit" disabled={saving} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600">
-              {saving ? 'Saving…' : 'Save'}
+              {saving ? 'Saving…' : isAdd ? 'Add' : 'Save'}
             </button>
           </div>
         </form>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -135,11 +135,14 @@ export function useWebSocket(jobId: string | null) {
     api.getJobStatus(jobId).then((jobStatus) => {
       if (cancelled) return;
       const p = jobStatus.progress || {};
-      if (p.percentage > 0 || p.current > 0 || p.total > 0) {
+      const perc = p.percentage ?? 0;
+      const cur = p.current ?? 0;
+      const tot = p.total ?? 0;
+      if (perc > 0 || cur > 0 || tot > 0) {
         setProgress({
-          current: p.current || 0,
-          total: p.total || 0,
-          percentage: p.percentage || 0,
+          current: cur,
+          total: tot,
+          percentage: perc,
         });
       } else {
         // Only reset to 0 if REST says progress is 0 (truly just started)
@@ -148,7 +151,7 @@ export function useWebSocket(jobId: string | null) {
       // If job already completed before we opened the modal
       if (jobStatus.status === 'complete' || jobStatus.status === 'error') {
         setComplete(true);
-        setSummary(p.summary || jobStatus);
+        setSummary(p.summary ?? jobStatus);
       }
     }).catch(() => {
       // REST fetch failed - start from zero, WebSocket will update

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -277,6 +277,7 @@ uvicorn api.main:app --reload --port 8000
 
       {cardModal && (
         <CardFormModal
+          mode={cardModal === 'add' ? 'add' : 'edit'}
           title={cardModal === 'add' ? 'Add card' : 'Edit card'}
           initial={cardModal === 'add' ? undefined : cardModal.card}
           onSubmit={handleCardSubmit}

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/design.md
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The dashboard has an Add card modal (`CardFormModal`) with manual fields: name, type, rarity, price, set. The backend exposes GET `/api/cards?search=...` (collection, name substring) and POST create for cards; `deckdex` already uses Scryfall via `CardFetcher` (search by name, card data). Scryfall offers a public autocomplete API (`/cards/autocomplete?q=...`) and card-by-name lookups. The goal is to simplify Add card to a single name field with hybrid autocomplete and to resolve type, rarity, price, set from the selected card (collection or Scryfall) instead of asking the user to type them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add card: one name field with autocomplete; suggestions from collection first, then Scryfall when collection has zero results or user chooses "Search catalog".
+- On selection, resolve full card data (type, rarity, set_name, price) from the selected source and create the card via existing POST create API.
+- Edit card: keep existing behaviour (all fields editable).
+
+**Non-Goals:**
+- Changing how Edit card or Delete card work beyond keeping edit form as-is.
+- Storing or exposing Scryfall-specific IDs beyond what the current data model supports.
+- Autocomplete for other fields (e.g. set or type) in this change.
+
+## Decisions
+
+### 1. Where to call Scryfall: backend proxy vs frontend direct
+
+- **Chosen:** Backend proxy for Scryfall autocomplete (e.g. GET `/api/cards/suggest?q=...`) and for resolving card-by-name (e.g. GET `/api/cards/resolve?name=...` or similar) so that Scryfall URL and rate limits are handled server-side and CORS is not a concern.
+- **Alternative:** Frontend calls Scryfall directly. Rejected to avoid CORS/rate-limit exposure and to centralize Scryfall usage in the backend (consistent with existing card image flow).
+
+### 2. Resolution flow: who fetches full card data
+
+- **Chosen:** Backend exposes a "resolve by name" endpoint that returns full card payload (type, rarity, set_name, price, etc.) from Scryfall (or from collection when the name matches a collection card). Frontend calls this on selection, then POSTs the returned payload to the existing create endpoint. Alternatively, a single "create by name" endpoint could resolve and create in one step; both are valid. This design assumes resolve + create (two calls) for clarity and reuse of existing POST create.
+- **Alternative:** Frontend calls Scryfall for resolution. Rejected in favour of keeping Scryfall behind the backend.
+
+### 3. When to show Scryfall suggestions
+
+- **Chosen:** (a) Always show collection suggestions while typing (debounced). (b) When collection returns zero results and query length ≥ 2, automatically show a second section "Other cards" from Scryfall. (c) Additionally show a "Search catalog" control (e.g. link or button) so the user can request Scryfall suggestions even when collection has results.
+- **Alternative:** Only show Scryfall after explicit "Search catalog" click. Chosen approach improves discoverability when the card is not in the collection.
+
+### 4. Debounce and request limits
+
+- **Chosen:** Debounce autocomplete requests (collection and Scryfall) by 250–300 ms. Limit suggestion count (e.g. 10 from collection, 10 from Scryfall) to keep responses small. Backend proxy for Scryfall SHALL respect Scryfall rate limits (e.g. one request per user keystroke after debounce is acceptable; avoid burst traffic).
+
+### 5. Add vs Edit form split
+
+- **Chosen:** Add card: single name field with autocomplete; no type, rarity, price, set inputs. Edit card: keep current form with all fields editable so users can correct or override data.
+
+## Risks / Trade-offs
+
+- **[Risk] Scryfall rate limits or downtime** → Mitigation: Backend proxy can cache suggest/resolve results briefly (e.g. 60s TTL per query); show a clear error in the UI if Scryfall is unavailable and allow manual name entry plus optional future "resolve" retry.
+- **[Risk] Collection and Scryfall names differ (e.g. language, punctuation)** → Mitigation: When user selects "from collection", use that card's stored data for create; when selecting from Scryfall, use Scryfall response. No cross-source matching required for this change.
+- **[Trade-off] Two requests on add (resolve then create)** → Acceptable for simplicity and reuse of existing create endpoint; can be collapsed into one "create by name" endpoint later if needed.
+
+## Migration Plan
+
+- No data migration. Deploy backend with new suggest and resolve endpoints; deploy frontend with updated Add card modal. Rollback: revert frontend to previous modal (name + type + rarity + price + set); backend can leave new endpoints in place (no breaking change).
+
+## Open Questions
+
+- None for MVP. Optional later: cache Scryfall resolve results per name in backend to reduce repeated lookups.

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/proposal.md
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Adding a new card in the dashboard currently requires typing the full card name and optionally filling type, rarity, price, and set by hand. This is error-prone and slow. Users should be able to find the card by partial name (autocomplete) and have the system fill the rest of the data from the catalog (Scryfall) or from the existing collection, so that the Add card flow is faster and more accurate.
+
+## What Changes
+
+- **Add card modal:** The "Add card" form SHALL be simplified to a single primary field: **card name**, with hybrid autocomplete. Type, rarity, price, and set SHALL NOT be user-filled on add; they SHALL be resolved when the user selects a card (from collection or Scryfall) and SHALL be sent to the create API automatically.
+- **Hybrid autocomplete:** While the user types in the name field, the UI SHALL suggest card names from (1) the current collection (existing GET `/api/cards?search=...`), and (2) when collection returns zero results (and optionally via an explicit "Search catalog" control), from Scryfall's autocomplete so that any MTG card can be added.
+- **Card resolution:** When the user confirms a selected card (from either source), the system SHALL obtain full card data (type, rarity, set_name, price where available) from Scryfall (or from the collection row when the suggestion came from the collection) and SHALL create the card via the existing create API with those fields populated.
+- **Edit card:** The Edit card modal SHALL continue to allow editing type, rarity, price, and set for existing cards (no change to edit behaviour).
+
+## Capabilities
+
+### New Capabilities
+
+- **card-name-autocomplete**: End-to-end behaviour for finding and adding a card by name: hybrid autocomplete (collection first, then Scryfall when needed), simplified Add card form (name-only input with suggestions), and resolving full card data from Scryfall or collection on selection before calling the create API.
+
+### Modified Capabilities
+
+- **web-dashboard-ui**: Add card form SHALL expose only a name field with autocomplete; type, rarity, price, set SHALL be resolved on selection and SHALL NOT be manual inputs on add. Edit card form SHALL retain editable type, rarity, price, set.
+- **web-api-backend**: SHALL provide a way for the client to get card name suggestions from Scryfall (e.g. GET `/api/cards/suggest?q=...` proxying Scryfall autocomplete) and SHALL support creating a card with full data resolved from Scryfall (e.g. endpoint that accepts a card name and returns or persists resolved Scryfall data, or the client resolves and POSTs full payload to existing POST create endpoint).
+
+## Impact
+
+- **Frontend:** `CardFormModal` (or equivalent Add card form) will be refactored: name input gains autocomplete UI (dropdown with two sections: "In your collection" and "Other cards" from Scryfall); type, rarity, price, set inputs removed for Add flow; on selection, client (or backend) resolves full card data and submits to POST create.
+- **Backend:** New endpoint(s) for Scryfall autocomplete proxy and/or card-by-name resolution; reuse of existing POST create card endpoint with full payload. Possible use of existing `deckdex` CardFetcher/Scryfall integration.
+- **Dependencies:** Scryfall API (autocomplete, card by name); existing collection API for suggestions. No new runtime dependencies beyond current stack.

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/specs/card-name-autocomplete/spec.md
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/specs/card-name-autocomplete/spec.md
@@ -1,0 +1,33 @@
+# Card Name Autocomplete (delta)
+
+End-to-end behaviour for finding and adding a card by name: hybrid autocomplete (collection first, then Scryfall when needed), simplified Add card form (name-only input with suggestions), and resolving full card data from Scryfall or collection on selection before calling the create API.
+
+## ADDED Requirements
+
+### Requirement: Add card flow SHALL use hybrid name autocomplete
+
+The Add card flow SHALL provide a single name field with autocomplete. Suggestions SHALL come first from the current collection (GET `/api/cards?search=...&limit=10`). When the collection returns zero results and the user has entered at least two characters, the system SHALL also request and display suggestions from the catalog (Scryfall) via the backend suggest endpoint. The UI SHALL offer an explicit "Search catalog" control so the user can request catalog suggestions even when collection has results. The dropdown SHALL present two sections when both sources are used: "In your collection" and "Other cards".
+
+#### Scenario: Typing in name field requests collection suggestions
+- **WHEN** the user types in the Add card name field (with debounce applied)
+- **THEN** the system requests GET `/api/cards?search=<query>&limit=10` and displays matching card names in a dropdown
+
+#### Scenario: Zero collection results triggers catalog suggestions
+- **WHEN** the collection returns zero results for the current query and the query length is at least 2
+- **THEN** the system requests catalog suggestions (e.g. GET `/api/cards/suggest?q=<query>`) and displays them in an "Other cards" section of the dropdown
+
+#### Scenario: Search catalog control requests catalog suggestions
+- **WHEN** the user activates the "Search catalog" control (e.g. link or button)
+- **THEN** the system requests catalog suggestions for the current query and displays them (e.g. in "Other cards" section) even if collection already has results
+
+#### Scenario: Selecting a collection suggestion uses that card's data
+- **WHEN** the user selects a suggestion that came from the collection
+- **THEN** the system uses that card's stored data (name, type, rarity, set_name, price, etc.) as the payload and SHALL call the create API with it (or resolve endpoint first if backend returns full row)
+
+#### Scenario: Selecting a catalog suggestion resolves then creates
+- **WHEN** the user selects a suggestion that came from the catalog (Scryfall)
+- **THEN** the system calls the backend resolve-by-name endpoint to obtain full card data, then SHALL call the create API with the resolved payload
+
+#### Scenario: Add form does not show type, rarity, price, set as inputs
+- **WHEN** the Add card modal is open
+- **THEN** the form SHALL display only the card name field (with autocomplete) and actions (e.g. Add, Cancel); type, rarity, price, and set SHALL NOT be manual input fields

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/specs/web-api-backend/spec.md
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/specs/web-api-backend/spec.md
@@ -1,0 +1,29 @@
+# Web API Backend (delta)
+
+Backend SHALL provide a way for the client to get card name suggestions from Scryfall and SHALL support obtaining full card data by name so the client can create a card with resolved type, rarity, price, set.
+
+## ADDED Requirements
+
+### Requirement: Backend SHALL provide card name suggest endpoint
+
+The system SHALL expose GET `/api/cards/suggest?q=<query>` (or equivalent) that returns a list of card names matching the query from Scryfall's autocomplete API. The endpoint SHALL proxy or call Scryfall and SHALL return a JSON array of name strings (or equivalent) for the client to display in the Add card autocomplete dropdown. The backend SHALL respect Scryfall rate limits (e.g. debouncing or caching is acceptable).
+
+#### Scenario: GET suggest returns names from Scryfall
+- **WHEN** client sends GET request to `/api/cards/suggest?q=lotus`
+- **THEN** system returns a JSON array of card names (e.g. from Scryfall autocomplete) that match "lotus"
+
+#### Scenario: Suggest handles empty or short query
+- **WHEN** client sends GET request to `/api/cards/suggest` with missing or very short q (e.g. length < 2)
+- **THEN** system returns an empty array or 400 without calling Scryfall
+
+### Requirement: Backend SHALL provide resolve card by name endpoint
+
+The system SHALL expose an endpoint (e.g. GET `/api/cards/resolve?name=<card_name>`) that, given a card name, returns full card data (type, rarity, set_name, price, and other fields needed for create) from Scryfall. If the name matches a card in the collection, the system MAY return that card's data instead. The response SHALL be suitable for the client to send as the body of POST create (or the backend MAY accept a create-by-name variant). This allows the Add card flow to resolve type, rarity, price, set without the user entering them.
+
+#### Scenario: GET resolve returns full card data for name
+- **WHEN** client sends GET request to `/api/cards/resolve?name=Black%20Lotus` (or equivalent)
+- **THEN** system returns JSON with at least name, type, rarity, set_name, price (and other fields as per card model) suitable for creating a card
+
+#### Scenario: Resolve returns 404 when card not found
+- **WHEN** client sends GET request to resolve with a name that Scryfall (and collection) cannot resolve
+- **THEN** system returns 404 (or appropriate error) so the client can show an error or allow manual retry

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/specs/web-dashboard-ui/spec.md
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/specs/web-dashboard-ui/spec.md
@@ -1,0 +1,21 @@
+# Web Dashboard UI (delta)
+
+Add card form SHALL expose only a name field with autocomplete; type, rarity, price, set SHALL be resolved on selection and SHALL NOT be manual inputs on add. Edit card form SHALL retain editable type, rarity, price, set.
+
+## ADDED Requirements
+
+### Requirement: Add card form SHALL have only name input with autocomplete
+
+The Add card modal SHALL display a single required field for card name. The name field SHALL support autocomplete with suggestions from the collection and, when applicable, from the catalog (Scryfall). The form SHALL NOT display input fields for type, rarity, price, or set when adding a card; those values SHALL be obtained by the system when the user selects a suggestion (from collection or catalog) and SHALL be sent in the create request. The Edit card modal SHALL continue to display and allow editing of name, type, rarity, price, and set for existing cards.
+
+#### Scenario: Add card modal shows only name field
+- **WHEN** the user opens the Add card modal
+- **THEN** the form SHALL show one text input for card name (with autocomplete) and Add/Cancel actions; it SHALL NOT show inputs for type, rarity, price, or set
+
+#### Scenario: Name field shows debounced autocomplete dropdown
+- **WHEN** the user types in the Add card name field
+- **THEN** after a short debounce (e.g. 250–300 ms) the system SHALL show a dropdown with suggestions (collection and optionally catalog), with sections labeled e.g. "In your collection" and "Other cards" when both are present
+
+#### Scenario: Edit card modal still has all fields
+- **WHEN** the user opens the Edit card modal for an existing card
+- **THEN** the form SHALL show editable fields for name, type, rarity, price, and set as today; behaviour SHALL be unchanged from current Edit card flow

--- a/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/tasks.md
+++ b/openspec/changes/archive/2026-02-08-add-card-name-autocomplete/tasks.md
@@ -1,0 +1,29 @@
+## 1. Backend: Scryfall suggest endpoint
+
+- [x] 1.1 Add GET /api/cards/suggest?q=... route that calls Scryfall autocomplete API and returns JSON array of card names; handle empty/short query (e.g. q length < 2) with empty array or 400
+- [x] 1.2 Reuse or wrap deckdex CardFetcher / Scryfall in backend for autocomplete (or call Scryfall HTTP directly); ensure rate limits are respected (no burst)
+
+## 2. Backend: Resolve card by name endpoint
+
+- [x] 2.1 Add GET /api/cards/resolve?name=... (or equivalent) that fetches full card data from Scryfall by name and returns payload matching card model (name, type, rarity, set_name, price, etc.) for client to use in create
+- [x] 2.2 Return 404 when card name cannot be resolved (Scryfall and optional collection lookup); map Scryfall response fields to existing card schema
+
+## 3. Frontend: API client for suggest and resolve
+
+- [x] 3.1 Add api.getCardSuggest(query) calling GET /api/cards/suggest?q=... and returning array of names
+- [x] 3.2 Add api.resolveCardByName(name) calling GET /api/cards/resolve?name=... and returning full card payload
+
+## 4. Frontend: Add card modal – autocomplete and simplified form
+
+- [x] 4.1 Refactor Add card form to show only name input (and Add/Cancel); remove type, rarity, price, set inputs from Add flow (keep them only for Edit)
+- [x] 4.2 Implement debounced (250–300 ms) name input: on change, fetch collection suggestions via GET /api/cards?search=<query>&limit=10; display dropdown with "In your collection" section
+- [x] 4.3 When collection returns zero results and query length >= 2, fetch catalog suggestions via api.getCardSuggest(query); display "Other cards" section in same dropdown
+- [x] 4.4 Add "Search catalog" control (link or button) that triggers catalog suggestions for current query even when collection has results; show "Other cards" section when used
+- [x] 4.5 On selecting a collection suggestion: use that card's data as create payload; call POST create (or resolve if backend returns id); close modal and refresh list
+- [x] 4.6 On selecting a catalog suggestion: call api.resolveCardByName(selectedName), then POST create with resolved payload; on 404 show error and keep modal open; on success close modal and refresh list
+- [x] 4.7 Keyboard and a11y: arrow keys to move in dropdown, Enter to select, Escape to close dropdown; focus management and aria attributes for combobox/autocomplete
+
+## 5. Verification and edge cases
+
+- [x] 5.1 Handle suggest/resolve API errors (toast or inline message); allow user to retry or type name manually and attempt add with resolve
+- [x] 5.2 Ensure Edit card modal still shows and submits all fields (name, type, rarity, price, set) unchanged

--- a/openspec/specs/card-name-autocomplete/spec.md
+++ b/openspec/specs/card-name-autocomplete/spec.md
@@ -1,0 +1,31 @@
+# Card Name Autocomplete
+
+End-to-end behaviour for finding and adding a card by name: hybrid autocomplete (collection first, then Scryfall when needed), simplified Add card form (name-only input with suggestions), and resolving full card data from Scryfall or collection on selection before calling the create API.
+
+### Requirement: Add card flow SHALL use hybrid name autocomplete
+
+The Add card flow SHALL provide a single name field with autocomplete. Suggestions SHALL come first from the current collection (GET `/api/cards?search=...&limit=10`). When the collection returns zero results and the user has entered at least two characters, the system SHALL also request and display suggestions from the catalog (Scryfall) via the backend suggest endpoint. The UI SHALL offer an explicit "Search catalog" control so the user can request catalog suggestions even when collection has results. The dropdown SHALL present two sections when both sources are used: "In your collection" and "Other cards".
+
+#### Scenario: Typing in name field requests collection suggestions
+- **WHEN** the user types in the Add card name field (with debounce applied)
+- **THEN** the system requests GET `/api/cards?search=<query>&limit=10` and displays matching card names in a dropdown
+
+#### Scenario: Zero collection results triggers catalog suggestions
+- **WHEN** the collection returns zero results for the current query and the query length is at least 2
+- **THEN** the system requests catalog suggestions (e.g. GET `/api/cards/suggest?q=<query>`) and displays them in an "Other cards" section of the dropdown
+
+#### Scenario: Search catalog control requests catalog suggestions
+- **WHEN** the user activates the "Search catalog" control (e.g. link or button)
+- **THEN** the system requests catalog suggestions for the current query and displays them (e.g. in "Other cards" section) even if collection already has results
+
+#### Scenario: Selecting a collection suggestion uses that card's data
+- **WHEN** the user selects a suggestion that came from the collection
+- **THEN** the system uses that card's stored data (name, type, rarity, set_name, price, etc.) as the payload and SHALL call the create API with it (or resolve endpoint first if backend returns full row)
+
+#### Scenario: Selecting a catalog suggestion resolves then creates
+- **WHEN** the user selects a suggestion that came from the catalog (Scryfall)
+- **THEN** the system calls the backend resolve-by-name endpoint to obtain full card data, then SHALL call the create API with the resolved payload
+
+#### Scenario: Add form does not show type, rarity, price, set as inputs
+- **WHEN** the Add card modal is open
+- **THEN** the form SHALL display only the card name field (with autocomplete) and actions (e.g. Add, Cancel); type, rarity, price, and set SHALL NOT be manual input fields

--- a/openspec/specs/web-api-backend/spec.md
+++ b/openspec/specs/web-api-backend/spec.md
@@ -91,3 +91,27 @@ The system SHALL provide GET `/api/cards/{id}/image` where `id` is the surrogate
 #### Scenario: Card image route does not conflict with get card by name
 - **WHEN** client sends GET request to `/api/cards/123/image`
 - **THEN** system treats this as a request for the image of card with id 123, not as a request for a card with name "123" or "123/image"
+
+### Requirement: Backend SHALL provide card name suggest endpoint
+
+The system SHALL expose GET `/api/cards/suggest?q=<query>` (or equivalent) that returns a list of card names matching the query from Scryfall's autocomplete API. The endpoint SHALL proxy or call Scryfall and SHALL return a JSON array of name strings (or equivalent) for the client to display in the Add card autocomplete dropdown. The backend SHALL respect Scryfall rate limits (e.g. debouncing or caching is acceptable).
+
+#### Scenario: GET suggest returns names from Scryfall
+- **WHEN** client sends GET request to `/api/cards/suggest?q=lotus`
+- **THEN** system returns a JSON array of card names (e.g. from Scryfall autocomplete) that match "lotus"
+
+#### Scenario: Suggest handles empty or short query
+- **WHEN** client sends GET request to `/api/cards/suggest` with missing or very short q (e.g. length < 2)
+- **THEN** system returns an empty array or 400 without calling Scryfall
+
+### Requirement: Backend SHALL provide resolve card by name endpoint
+
+The system SHALL expose an endpoint (e.g. GET `/api/cards/resolve?name=<card_name>`) that, given a card name, returns full card data (type, rarity, set_name, price, and other fields needed for create) from Scryfall. If the name matches a card in the collection, the system MAY return that card's data instead. The response SHALL be suitable for the client to send as the body of POST create (or the backend MAY accept a create-by-name variant). This allows the Add card flow to resolve type, rarity, price, set without the user entering them.
+
+#### Scenario: GET resolve returns full card data for name
+- **WHEN** client sends GET request to `/api/cards/resolve?name=Black%20Lotus` (or equivalent)
+- **THEN** system returns JSON with at least name, type, rarity, set_name, price (and other fields as per card model) suitable for creating a card
+
+#### Scenario: Resolve returns 404 when card not found
+- **WHEN** client sends GET request to resolve with a name that Scryfall (and collection) cannot resolve
+- **THEN** system returns 404 (or appropriate error) so the client can show an error or allow manual retry

--- a/openspec/specs/web-dashboard-ui/spec.md
+++ b/openspec/specs/web-dashboard-ui/spec.md
@@ -177,3 +177,19 @@ The system SHALL allow the user to click on a card table row to open a read-only
 #### Scenario: Dashboard wires table to card detail modal
 - **WHEN** the dashboard renders the card table
 - **THEN** the table is configured with a row-click handler that opens the card detail modal for the clicked card, and the modal receives the selected card and uses the image API for that card's id
+
+### Requirement: Add card form SHALL have only name input with autocomplete
+
+The Add card modal SHALL display a single required field for card name. The name field SHALL support autocomplete with suggestions from the collection and, when applicable, from the catalog (Scryfall). The form SHALL NOT display input fields for type, rarity, price, or set when adding a card; those values SHALL be obtained by the system when the user selects a suggestion (from collection or catalog) and SHALL be sent in the create request. The Edit card modal SHALL continue to display and allow editing of name, type, rarity, price, and set for existing cards.
+
+#### Scenario: Add card modal shows only name field
+- **WHEN** the user opens the Add card modal
+- **THEN** the form SHALL show one text input for card name (with autocomplete) and Add/Cancel actions; it SHALL NOT show inputs for type, rarity, price, or set
+
+#### Scenario: Name field shows debounced autocomplete dropdown
+- **WHEN** the user types in the Add card name field
+- **THEN** after a short debounce (e.g. 250–300 ms) the system SHALL show a dropdown with suggestions (collection and optionally catalog), with sections labeled e.g. "In your collection" and "Other cards" when both are present
+
+#### Scenario: Edit card modal still has all fields
+- **WHEN** the user opens the Edit card modal for an existing card
+- **THEN** the form SHALL show editable fields for name, type, rarity, price, and set as today; behaviour SHALL be unchanged from current Edit card flow


### PR DESCRIPTION
- Backend: GET /api/cards/suggest and GET /api/cards/resolve (Scryfall proxy)
- Add card form: name-only input with hybrid autocomplete (collection + Scryfall)
- Edit card form: unchanged (all fields)
- Fix TypeScript: CardDetailModal card.id, useApi progress/summary types
- OpenSpec: archive add-card-name-autocomplete and sync specs to main