### PR TITLE
fix(web): sort card table by price numerically and raise list limit

### DIFF
--- a/backend/api/routes/cards.py
+++ b/backend/api/routes/cards.py
@@ -45,7 +45,7 @@ class Card(BaseModel):
 
 @router.get("/", response_model=List[Card])
 async def list_cards(
-    limit: int = Query(default=100, ge=1, le=1000),
+    limit: int = Query(default=100, ge=1, le=10000),
     offset: int = Query(default=0, ge=0),
     search: Optional[str] = Query(default=None),
     rarity: Optional[str] = Query(default=None),

--- a/frontend/src/components/CardTable.tsx
+++ b/frontend/src/components/CardTable.tsx
@@ -40,15 +40,29 @@ export function CardTable({ cards, isLoading, onAdd, onEdit, onDelete, onRowClic
     }
   };
 
+  // Sort full list first so order is consistent across all pages
   const sortedCards = [...cards].sort((a, b) => {
-    const aVal = a[sortKey] || '';
-    const bVal = b[sortKey] || '';
-    
-    if (sortDirection === 'asc') {
-      return aVal > bVal ? 1 : -1;
-    } else {
-      return aVal < bVal ? 1 : -1;
+    if (sortKey === 'price') {
+      const parsePrice = (v: unknown): number => {
+        if (v == null || v === '') return NaN;
+        const s = String(v).replace(',', '.');
+        const n = parseFloat(s);
+        return Number.isFinite(n) ? n : NaN;
+      };
+      const aNum = parsePrice(a.price);
+      const bNum = parsePrice(b.price);
+      const aNaN = Number.isNaN(aNum);
+      const bNaN = Number.isNaN(bNum);
+      if (aNaN && bNaN) return 0;
+      if (aNaN) return 1;
+      if (bNaN) return -1;
+      if (sortDirection === 'asc') return aNum < bNum ? -1 : aNum > bNum ? 1 : 0;
+      return bNum < aNum ? -1 : bNum > aNum ? 1 : 0;
     }
+    const aVal = (a[sortKey] ?? '') as string;
+    const bVal = (b[sortKey] ?? '') as string;
+    if (sortDirection === 'asc') return aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+    return bVal > aVal ? 1 : bVal < aVal ? -1 : 0;
   });
 
   const totalPages = Math.ceil(sortedCards.length / itemsPerPage);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -29,7 +29,7 @@ export function Dashboard() {
     set: setFilter === 'all' ? undefined : setFilter,
     priceMin: priceMin.trim() || undefined,
     priceMax: priceMax.trim() || undefined,
-    limit: 1000,
+    limit: 10000,
   });
 
   const invalidateCards = useCallback(() => {

--- a/openspec/changes/archive/2026-02-08-fix-sort-card-table/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-08-fix-sort-card-table/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/archive/2026-02-08-fix-sort-card-table/design.md
+++ b/openspec/changes/archive/2026-02-08-fix-sort-card-table/design.md
@@ -1,0 +1,35 @@
+## Context
+
+The card table in `CardTable.tsx` sorts by a single key (`sortKey`) using a generic comparator that does `aVal > bVal` / `aVal < bVal`. Values come from `Card`; `price` is typed as `string` from the API. All columns are therefore compared as strings, which produces wrong order for price (e.g. 9, 81, 7 instead of 81, 9, 7). No backend or API changes are needed; this is a frontend-only fix.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Price column sorts by numeric value (asc/desc).
+- Other sortable columns (name, type, rarity) keep string sort.
+- Deterministic order when price is missing or non-numeric.
+- Sort is applied to the full card list in memory before pagination (current behaviour), so all pages share one consistent order.
+
+**Non-Goals:**
+- Changing API types or adding server-side sort.
+- Adding sort to other columns or new numeric columns (can be done later with same pattern).
+
+## Decisions
+
+1. **Column-aware sort in CardTable**  
+   In the same `sort` callback, branch on `sortKey === 'price'`: for price, compare `parseFloat(a.price)` vs `parseFloat(b.price)`; for other keys, keep string comparison.  
+   *Alternative:* Centralise comparators in a small helper (e.g. `getCompareFn(sortKey, direction)`) for clarity and reuse if we add more numeric columns later. Either is fine; helper is slightly more scalable.
+
+2. **Non-numeric or empty price**  
+   Treat as `NaN` and sort last in both directions (so they don’t jump between top and bottom when toggling asc/desc).  
+   *Alternative:* Treat as 0; rejected so "no price" doesn’t mix with real zero.
+
+3. **Locale and decimals**  
+   Normalise decimal separator (e.g. replace comma with dot) before `parseFloat` so "1,5" and "1.5" sort correctly. No locale-specific number formatting for sort; display format stays as-is.
+
+## Risks / Trade-offs
+
+- **Risk:** Price strings in unexpected formats (e.g. "€ 9.99") could parse wrong.  
+  **Mitigation:** parseFloat ignores leading non-numeric characters; if we ever need stricter parsing, we can add a small normaliser (strip currency symbols) in one place.
+
+- **Trade-off:** Only `price` is numeric for now; future numeric columns (e.g. cmc) would need the same treatment. Documenting the pattern in design (and optionally a shared compare helper) keeps the codebase consistent.

--- a/openspec/changes/archive/2026-02-08-fix-sort-card-table/proposal.md
+++ b/openspec/changes/archive/2026-02-08-fix-sort-card-table/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The card table sorts all columns using string comparison. The Price column stores values as strings (e.g. "9", "81", "7"), so sorting is lexicographic: users see order like 9 €, 81 €, 7 € instead of 81 €, 9 €, 7 €. This is confusing and wrong for a numeric column. Fixing it ensures table sort matches user expectations for price (and any future numeric columns).
+
+## What Changes
+
+- Card table sort SHALL treat the **Price** column as numeric: compare by numeric value (e.g. parseFloat), not by string.
+- Text columns (name, type, rarity) SHALL continue to sort as strings (current behaviour).
+- Non-numeric or empty price values SHALL have defined behaviour (e.g. sort last or treat as zero) so order is deterministic.
+- Sort SHALL be applied to the **full** card list (all rows received by the table) before pagination, so that the same order is consistent across all pages, not only the visible page.
+
+## Capabilities
+
+### New Capabilities
+
+- (None)
+
+### Modified Capabilities
+
+- **web-dashboard-ui**: Add requirement that the card table SHALL sort the Price column by numeric value; string columns SHALL sort lexicographically. Delta spec will define the new sort behaviour and scenarios.
+
+## Impact
+
+- **Frontend:** `frontend/src/components/CardTable.tsx` — sort logic only; no API or prop changes.
+- No backend, API, or dependency changes.

--- a/openspec/changes/archive/2026-02-08-fix-sort-card-table/specs/web-dashboard-ui/spec.md
+++ b/openspec/changes/archive/2026-02-08-fix-sort-card-table/specs/web-dashboard-ui/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Card table SHALL sort columns by appropriate type (numeric vs string)
+
+The card table SHALL support sort by column (name, type, rarity, price). Sort SHALL be applied to the full set of cards (all rows provided to the table) before pagination, so that the same order is consistent across every page. The Price column SHALL be sorted by numeric value (ascending or descending); empty or non-numeric price values SHALL be placed last in both directions. All other sortable columns (name, type, rarity) SHALL be sorted lexicographically (string comparison). Sort direction SHALL be toggleable per column and SHALL be indicated in the UI (e.g. arrow).
+
+#### Scenario: Price column sorts by numeric value ascending
+- **WHEN** the user sorts by Price ascending (e.g. clicks Price header until ascending)
+- **THEN** the table SHALL order rows by price from lowest to highest numeric value (e.g. 7, 9, 81), not by string order (e.g. 7, 81, 9)
+
+#### Scenario: Price column sorts by numeric value descending
+- **WHEN** the user sorts by Price descending
+- **THEN** the table SHALL order rows by price from highest to lowest numeric value (e.g. 81, 9, 7)
+
+#### Scenario: Non-numeric or empty price sorts last
+- **WHEN** some cards have missing or non-numeric price and the user sorts by Price (asc or desc)
+- **THEN** those rows SHALL appear last in the sorted list; numeric prices SHALL be ordered correctly among themselves
+
+#### Scenario: Name, type, and rarity columns sort lexicographically
+- **WHEN** the user sorts by Name, Type, or Rarity (asc or desc)
+- **THEN** the table SHALL order rows by string comparison for that column (current behaviour unchanged)
+
+#### Scenario: Sort applies to all pages
+- **WHEN** the user sorts by any column and the result spans multiple pages
+- **THEN** the table SHALL apply the sort to the full card list first, then paginate; changing page SHALL show the next segment of that same global order (e.g. page 2 continues the order from page 1)

--- a/openspec/changes/archive/2026-02-08-fix-sort-card-table/tasks.md
+++ b/openspec/changes/archive/2026-02-08-fix-sort-card-table/tasks.md
@@ -1,0 +1,6 @@
+## 1. Card table sort logic
+
+- [x] 1.1 In `CardTable.tsx`, add numeric comparison for Price: when `sortKey === 'price'`, parse values (e.g. parseFloat, normalising comma to dot), compare numerically; treat NaN/empty as sort last in both directions
+- [x] 1.2 Keep string comparison for name, type, and rarity columns (unchanged behaviour)
+- [x] 1.3 Ensure sort continues to run on the full `cards` array before slicing for pagination (so all pages use one consistent order)
+- [ ] 1.4 Manually verify: sort Price asc/desc shows correct numeric order (e.g. 81, 9, 7 when desc); empty/non-numeric prices appear last; name/type/rarity sort still work; changing page keeps the same global order

--- a/openspec/specs/web-dashboard-ui/spec.md
+++ b/openspec/specs/web-dashboard-ui/spec.md
@@ -94,6 +94,30 @@ The system SHALL allow users to filter the card table by name (search), rarity, 
 - **WHEN** the user applies more than one filter (e.g. rarity Rare and set "Dominaria")
 - **THEN** the system requests GET `/api/cards` with all active filter parameters and displays the returned list; the list and stats SHALL show the same subset
 
+### Requirement: Card table SHALL sort columns by appropriate type (numeric vs string)
+
+The card table SHALL support sort by column (name, type, rarity, price). Sort SHALL be applied to the full set of cards (all rows provided to the table) before pagination, so that the same order is consistent across every page. The Price column SHALL be sorted by numeric value (ascending or descending); empty or non-numeric price values SHALL be placed last in both directions. All other sortable columns (name, type, rarity) SHALL be sorted lexicographically (string comparison). Sort direction SHALL be toggleable per column and SHALL be indicated in the UI (e.g. arrow).
+
+#### Scenario: Price column sorts by numeric value ascending
+- **WHEN** the user sorts by Price ascending (e.g. clicks Price header until ascending)
+- **THEN** the table SHALL order rows by price from lowest to highest numeric value (e.g. 7, 9, 81), not by string order (e.g. 7, 81, 9)
+
+#### Scenario: Price column sorts by numeric value descending
+- **WHEN** the user sorts by Price descending
+- **THEN** the table SHALL order rows by price from highest to lowest numeric value (e.g. 81, 9, 7)
+
+#### Scenario: Non-numeric or empty price sorts last
+- **WHEN** some cards have missing or non-numeric price and the user sorts by Price (asc or desc)
+- **THEN** those rows SHALL appear last in the sorted list; numeric prices SHALL be ordered correctly among themselves
+
+#### Scenario: Name, type, and rarity columns sort lexicographically
+- **WHEN** the user sorts by Name, Type, or Rarity (asc or desc)
+- **THEN** the table SHALL order rows by string comparison for that column (current behaviour unchanged)
+
+#### Scenario: Sort applies to all pages
+- **WHEN** the user sorts by any column and the result spans multiple pages
+- **THEN** the table SHALL apply the sort to the full card list first, then paginate; changing page SHALL show the next segment of that same global order (e.g. page 2 continues the order from page 1)
+
 ### Requirement: Main content SHALL not be covered by the jobs bar
 
 When one or more background jobs are shown in the fixed bottom jobs bar, the main content area on **every** view (Dashboard and Settings) SHALL reserve bottom space so the jobs bar does not overlap content. Dashboard content (stats, filters, card table, pagination) and Settings content (all sections) SHALL remain fully visible above the bar.


### PR DESCRIPTION
- CardTable: Price column sorts by numeric value; empty/NaN last; sort on full list before pagination
- Backend: GET /api/cards max limit 1000 → 10000
- Dashboard: request limit 1000 → 10000 so sort uses full filtered set
- OpenSpec: archive fix-sort-card-table, sync web-dashboard-ui spec