### PR TITLE
feat(web): single-card update price from card detail modal

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -174,6 +174,17 @@ export const api = {
     return response.json();
   },
 
+  triggerSingleCardPriceUpdate: async (cardId: number): Promise<JobResponse> => {
+    const response = await apiFetch(`${API_BASE}/prices/update/${cardId}`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.detail || 'Failed to trigger single-card price update');
+    }
+    return response.json();
+  },
+
   getJobs: async (): Promise<JobStatus[]> => {
     const response = await apiFetch(`${API_BASE}/jobs`);
     if (!response.ok) throw new Error('Failed to fetch jobs');

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -37,6 +37,20 @@ export function Dashboard() {
     queryClient.invalidateQueries({ queryKey: ['stats'] });
   }, [queryClient]);
 
+  const refetchAfterPriceUpdate = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['cards'] });
+    await queryClient.invalidateQueries({ queryKey: ['stats'] });
+    const cardId = detailCard?.id;
+    if (cardId != null) {
+      try {
+        const updated = await api.getCard(String(cardId));
+        setDetailCard((prev) => (prev?.id === updated.id ? updated : prev));
+      } catch {
+        // ignore
+      }
+    }
+  }, [queryClient, detailCard?.id]);
+
   const handleAddCard = useCallback(() => setCardModal('add'), []);
   const handleEditCard = useCallback((card: Card) => setCardModal({ card }), []);
   const handleRowClick = useCallback((card: Card) => setDetailCard(card), []);
@@ -231,6 +245,7 @@ uvicorn api.main:app --reload --port 8000
         <CardDetailModal
           card={detailCard}
           onClose={() => setDetailCard(null)}
+          onPriceUpdateJobComplete={refetchAfterPriceUpdate}
         />
       )}
     </div>

--- a/openspec/changes/archive/2026-02-08-card-detail-update-price/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-08-card-detail-update-price/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/archive/2026-02-08-card-detail-update-price/design.md
+++ b/openspec/changes/archive/2026-02-08-card-detail-update-price/design.md
@@ -1,0 +1,67 @@
+## Context
+
+- **Card detail modal**: `CardDetailModal` receives a `Card` and displays image (from GET `/api/cards/{id}/image`) and metadata including price. It is read-only; there is no action today to refresh the card's price.
+- **Jobs**: The app uses `ActiveJobsContext` (addJob/removeJob) and an `ActiveJobs` bar at the bottom. Jobs are created by calling the API (e.g. POST `/api/prices/update`), then `addJob(jobId, jobType)` so the bar shows progress via WebSocket. Same pattern is used for "Process Cards" and "Update Prices" from Settings → Deck Actions.
+- **Backend price update**: POST `/api/prices/update` (no body) starts a full collection price update. It uses `ProcessorService.update_prices_async()`, which runs `MagicCardProcessor.process_card_data()` in update_prices mode: repository `get_cards_for_price_update()` returns all cards as `(id, name, price_eur)`; `update_prices_data_repo(cards)` fetches Scryfall prices and updates the repository. Only one bulk "update_prices" job is allowed at a time (409 if already running).
+- **Processor**: `MagicCardProcessor.update_prices_data_repo(cards)` already accepts a list of `(card_id, name, current_price_str)`. Passing a single-element list would update only that card; the processor does not currently expose an entry point that takes a subset of card ids.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add an "Update price" button in the card detail modal when the card has an id.
+- Expose a backend way to trigger a price update for one card by id, returning a job_id and using the same job/WebSocket/completion flow as bulk update.
+- Reuse the existing jobs bar: the new job appears at the bottom with a clear label (e.g. "Update price") and the same UX (progress, completion, cancel if we keep it consistent).
+- When the single-card "Update price" job completes, refresh immediately: total value (stats), the price in the open card detail modal (if still that card), and the card table rows.
+
+**Non-Goals:**
+
+- Changing bulk "Update Prices" behavior or its 409 semantics.
+- Adding a separate "single-card jobs" UI; we reuse the global jobs bar.
+
+## Decisions
+
+### 1. API shape: new endpoint vs optional body
+
+- **Chosen:** New endpoint **POST `/api/prices/update/{card_id}`** (path parameter).
+- **Alternatives:** POST `/api/prices/update` with body `{ "card_id": 123 }`. Rejected to keep the bulk endpoint body-free and to make the single-card case explicit and easy to document.
+
+### 2. Where to implement "update only these cards"
+
+- **Chosen:** Add a method in **deckdex** (e.g. `MagicCardProcessor.update_prices_for_card_ids(card_ids: List[int])`) that builds the list of `(id, name, price)` via `get_card_by_id` for each id, then calls existing `update_prices_data_repo(cards)`. The backend then calls this path when handling POST `/api/prices/update/{card_id}`.
+- **Rationale:** Keeps Scryfall and repository logic in one place; backend stays a thin orchestrator. No new repository method required; `get_card_by_id` is sufficient.
+
+### 3. Backend job type and concurrency
+
+- **Chosen:** Register the job with type **"Update price"** (singular) so the bar shows a distinct label. Allow single-card update jobs to run **independently** of the bulk update job: do not block on "another price update job is already running" for this endpoint. Multiple single-card jobs may run concurrently.
+- **Rationale:** Single-card updates are quick and low-impact; blocking them on a long bulk run would hurt UX. The 409 rule remains for the bulk endpoint only.
+
+### 4. Frontend: how to trigger and register the job
+
+- **Chosen:** In `CardDetailModal`, add a button "Update price" visible only when `card.id != null`. On click: call new API method (e.g. `triggerSingleCardPriceUpdate(card.id)`), get `job_id`, then `useActiveJobs().addJob(jobId, 'Update price', onPriceUpdateJobComplete)` where `onPriceUpdateJobComplete` is a callback provided by the Dashboard. Disable the button or show loading state while the start request is in flight.
+- **Rationale:** Matches existing pattern (Settings buttons that start jobs and call addJob). The optional third argument to addJob is an onFinished callback; when the job completes, the jobs bar invokes it so the Dashboard can refetch stats, cards, and the open card (by id) and update the modal and table.
+
+### 5. Refresh on job completion
+
+- **Chosen:** Extend `ActiveJobsContext.addJob(jobId, jobType, onFinished?)`. When a job completes (in the jobs bar, when WebSocket reports complete), call the stored onFinished for that jobId before removing the job from the bar. Dashboard provides a callback that: invalidates cards and stats queries (so total value and table refetch), then fetches the current open card by id via GET `/api/cards/{id}` and updates `detailCard` only if it still refers to that card (so the modal price updates without reopening if the user had closed it).
+- **Rationale:** User sees updated total value, modal price, and table rows immediately when the job finishes, without closing the modal or refreshing the page.
+
+### 6. Scryfall lookup name for price update
+
+- **Chosen:** Use **english_name** when available (else **name**) for Scryfall API lookup in both bulk and single-card price update. Repository `get_cards_for_price_update()` returns (card_id, name_for_scryfall, price) with name_for_scryfall = COALESCE(english_name, name); processor `update_prices_for_card_ids` builds the same from get_card_by_id.
+- **Rationale:** Scryfall expects canonical English names; cards with a localised display name (e.g. Spanish) often failed to resolve; filling english_name (e.g. from Scryfall on process) fixes price lookup.
+- **Scope:** This is a deckdex/repository and processor change only; the web API backend (POST `/api/prices/update`, POST `/api/prices/update/{card_id}`) is unchanged and does not expose or require english_name.
+
+## Risks / Trade-offs
+
+- **Card without id:** Cards that are not yet persisted (e.g. no id) will not show the button; this is by design and documented in the proposal.
+- **Scryfall/credentials:** Same failure modes as bulk update (e.g. missing Scryfall credentials, rate limits, card not found). The job will report completion or error via the same WebSocket/summary; no special handling required in the UI beyond what the jobs bar already shows.
+- **Concurrency:** Allowing single-card and bulk runs together could increase load on Scryfall. Mitigation: single-card runs are infrequent and one-off; if needed, a future change can add a global "one price-update job at a time" (any type) policy.
+
+## Migration Plan
+
+- No data migration. Deploy backend with new route and (if added) deckdex method; deploy frontend with updated modal and API client. Rollback: revert frontend and backend; no schema or data changes.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-02-08-card-detail-update-price/proposal.md
+++ b/openspec/changes/archive/2026-02-08-card-detail-update-price/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When a user opens the card detail modal (by clicking a row), they see the current price but have no way to refresh only that card's price. Today they must go to Settings → Deck Actions and run "Update Prices" for the entire collection. A single-card update from the modal improves UX and reuses the existing app-wide jobs bar so progress and completion stay consistent with the rest of the app.
+
+## What Changes
+
+- Add an **"Update price"** button inside the card detail modal. It is shown only when the card has an `id` (persisted in the collection).
+- New backend capability: **single-card price update**. The backend SHALL accept a request to update the price of one card by id and SHALL run it as a job (same job infrastructure: job_id, WebSocket progress, completion summary). The job SHALL appear in the same bottom jobs bar with a distinct label (e.g. "Update price").
+- **Refresh on job completion**: When the single-card "Update price" job completes, the app SHALL refresh immediately: (1) total value (and stats), (2) the price shown in the card detail modal if it is still open for that card, and (3) the card table rows so the updated price is visible in the list.
+- No change to full "Update Prices" behavior or to the existing POST `/api/prices/update` contract for bulk updates.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change extends existing capabilities.
+
+### Modified Capabilities
+
+- **card-detail-modal**: The modal SHALL offer an "Update price" action when the displayed card has an id. Triggering it SHALL start a single-card price-update job and SHALL register that job with the global jobs state so it appears in the app-wide jobs bar. When that job completes, the system SHALL refresh total value (stats), the price displayed in the modal (if still open for that card), and the card table so all displayed data reflects the new price.
+- **web-api-backend**: The system SHALL provide an endpoint (or an optional parameter on the existing price-update endpoint) to trigger a price update for a single card by id. The response SHALL be a job_id and the job SHALL use the same progress/WebSocket and completion semantics as the bulk price update job. Single-card update jobs MAY run concurrently with each other or with the bulk update job (policy left to design).
+
+## Impact
+
+- **Frontend**: CardDetailModal component, API client (new method to trigger single-card update), ActiveJobs context (addJob with optional onFinished callback), Dashboard refetch on job completion (invalidate cards/stats, refetch open card by id). Jobs bar calls onFinished when a job completes so the dashboard can refresh.
+- **Backend**: New route POST `/api/prices/update/{card_id}`, ProcessorService to run a one-card price update as an async job with progress callbacks. No change to request/response shape for the english_name behaviour (that is internal to deckdex/repository).
+- **Core/processor**: Narrow path to run price update for a given list of card ids (e.g. one id) reusing existing Scryfall fetch and repository update logic; use english_name for Scryfall lookup when available (bulk and single-card).
+- **Jobs UI**: No structural change; a new job type label (e.g. "Update price") will appear in the same bar.

--- a/openspec/changes/archive/2026-02-08-card-detail-update-price/specs/card-detail-modal/spec.md
+++ b/openspec/changes/archive/2026-02-08-card-detail-update-price/specs/card-detail-modal/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Card detail modal SHALL offer Update price action when card has id
+
+The system SHALL display an "Update price" action (e.g. button) inside the card detail modal when the displayed card has a non-null id (i.e. the card is persisted in the collection). When the user triggers this action, the system SHALL request a single-card price update from the backend (e.g. POST `/api/prices/update/{card_id}`), SHALL receive a job_id in the response, and SHALL register that job with the global jobs state so the job appears in the app-wide jobs bar with a label such as "Update price". The modal MAY remain open; the user SHALL see the job progress and completion in the bottom jobs bar. The action SHALL NOT be shown when the card has no id.
+
+#### Scenario: Update price button visible when card has id
+- **WHEN** the card detail modal is open with a card that has an id
+- **THEN** the modal displays an "Update price" action (e.g. button) that the user can click
+
+#### Scenario: Update price button not shown when card has no id
+- **WHEN** the card detail modal is open with a card that has no id (e.g. null or undefined)
+- **THEN** the modal does not display the "Update price" action
+
+#### Scenario: Triggering Update price starts job and shows it in jobs bar
+- **WHEN** the user clicks the "Update price" action in the modal for a card with an id
+- **THEN** the system sends a request to the backend to start a single-card price update for that card's id, receives a job_id, and adds the job to the global jobs state so it appears in the app-wide jobs bar (e.g. with label "Update price")
+
+### Requirement: System SHALL refresh displayed data when single-card Update price job completes
+
+When the single-card "Update price" job (started from the card detail modal) completes, the system SHALL refresh the following so they reflect the updated price: (1) total value and aggregate stats (e.g. Total Value, Average Price on the dashboard), (2) the price displayed in the card detail modal if the modal is still open for that same card, and (3) the card table rows so the updated price is visible in the list. The refresh SHALL occur when the job completes (e.g. when the job bar reports completion), without requiring the user to close the modal or reload the page.
+
+#### Scenario: Total value and stats refresh when Update price job completes
+- **WHEN** a single-card "Update price" job started from the card detail modal completes successfully
+- **THEN** the dashboard total value (and any other stats derived from the collection) are refreshed so they reflect the updated price
+
+#### Scenario: Modal price updates when job completes and modal still open for that card
+- **WHEN** a single-card "Update price" job completes and the card detail modal is still open for the same card that was updated
+- **THEN** the price shown in the modal is updated to the new value without the user closing or reopening the modal
+
+#### Scenario: Card table rows show updated price after job completes
+- **WHEN** a single-card "Update price" job completes
+- **THEN** the card table (list) is refreshed so the row for that card displays the updated price

--- a/openspec/changes/archive/2026-02-08-card-detail-update-price/specs/web-api-backend/spec.md
+++ b/openspec/changes/archive/2026-02-08-card-detail-update-price/specs/web-api-backend/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Backend SHALL provide single-card price update endpoint
+
+The system SHALL provide POST `/api/prices/update/{card_id}` where `card_id` is the surrogate card id (integer). The endpoint SHALL start a background job that updates only that card's price (e.g. from Scryfall) and writes the result to the collection. The response SHALL be JSON with job_id (and optionally status/message) so the client can poll GET `/api/jobs/{job_id}` or use the existing WebSocket progress flow. The job SHALL use the same progress and completion semantics as the bulk price update job (progress events, completion summary, cancellation via POST `/api/jobs/{id}/cancel`). Single-card update jobs MAY run concurrently with each other and with the bulk POST `/api/prices/update` job; the 409 conflict SHALL apply only to concurrent bulk price update requests, not to single-card updates. If the card_id does not exist, the system SHALL return 404.
+
+#### Scenario: POST single-card price update returns job_id
+- **WHEN** client sends POST request to `/api/prices/update/{card_id}` with a valid card id
+- **THEN** system responds with status 200 and JSON containing job_id (and optionally status/message), and starts a background job that updates that card's price
+
+#### Scenario: Single-card price update job uses same progress and completion as bulk
+- **WHEN** a single-card price update job is running
+- **THEN** the job reports progress and completion via the same mechanism as the bulk price update (e.g. WebSocket progress, GET /api/jobs/{id} with status and summary when complete)
+
+#### Scenario: Single-card update returns 404 when card not found
+- **WHEN** client sends POST request to `/api/prices/update/{card_id}` and no card exists with that id
+- **THEN** system responds with status 404 and does not create a job
+
+#### Scenario: Single-card update not blocked by bulk price update
+- **WHEN** a bulk price update job is already running (POST `/api/prices/update` returned 200 and job is in progress)
+- **THEN** a client MAY successfully start a single-card price update via POST `/api/prices/update/{card_id}` and receive a job_id without receiving 409

--- a/openspec/changes/archive/2026-02-08-card-detail-update-price/tasks.md
+++ b/openspec/changes/archive/2026-02-08-card-detail-update-price/tasks.md
@@ -1,0 +1,32 @@
+## 1. Core (deckdex)
+
+- [x] 1.1 Add `MagicCardProcessor.update_prices_for_card_ids(card_ids: List[int])` that builds list of `(id, name, price)` via `get_card_by_id` for each id and calls existing `update_prices_data_repo(cards)`; handle missing cards (skip or error per design).
+
+## 2. Backend API
+
+- [x] 2.1 Add route POST `/api/prices/update/{card_id}`; resolve card_id to integer; return 404 if card does not exist.
+- [x] 2.2 In ProcessorService add path to run single-card price update (e.g. method that calls processor `update_prices_for_card_ids([card_id])` in a thread with same progress callback/WebSocket pattern as bulk update).
+- [x] 2.3 Register single-card job with distinct job type (e.g. "Update price"); do not apply 409 conflict for this endpoint when bulk price update is running.
+
+## 3. Frontend API client
+
+- [x] 3.1 Add `triggerSingleCardPriceUpdate(cardId: number)` in `api/client.ts` that POSTs to `/api/prices/update/{card_id}` and returns `Promise<{ job_id: string }>` (or existing JobResponse shape).
+
+## 4. Card detail modal
+
+- [x] 4.1 In CardDetailModal render an "Update price" button only when `card.id != null`.
+- [x] 4.2 On button click call `triggerSingleCardPriceUpdate(card.id)`, then `useActiveJobs().addJob(jobId, 'Update price')` so the job appears in the app-wide jobs bar.
+- [x] 4.3 Disable button or show loading state while the start request is in flight (optional but recommended).
+
+## 5. Refresh on job completion
+
+- [x] 5.1 Extend ActiveJobsContext.addJob to accept optional onFinished callback; store per jobId and invoke when that job completes (before removing from bar).
+- [x] 5.2 In ActiveJobs/JobEntry, when job completes call onJobFinished(jobId) so context can run the registered callback.
+- [x] 5.3 Dashboard: implement refetch callback (invalidate cards + stats; fetch open card by id and setDetailCard only if still same card); pass to CardDetailModal as onPriceUpdateJobComplete.
+- [x] 5.4 CardDetailModal: accept onPriceUpdateJobComplete and pass it as third argument to addJob when starting Update price job.
+
+## 6. Verification
+
+- [ ] 6.1 Manually verify: open modal for a card with id, click "Update price", confirm job appears in bottom bar and completes; confirm total value, modal price and table row update automatically when job completes.
+- [ ] 6.2 Verify modal does not show "Update price" when card has no id (if such case exists in the app).
+- [ ] 6.3 Verify POST `/api/prices/update/{card_id}` returns 404 for non-existent card id.

--- a/openspec/specs/card-detail-modal/spec.md
+++ b/openspec/specs/card-detail-modal/spec.md
@@ -25,3 +25,35 @@ The system SHALL provide a modal component that shows the selected card's image 
 #### Scenario: Modal can be closed
 - **WHEN** the user closes the modal (e.g. close button or overlay click)
 - **THEN** the modal is dismissed and focus returns to the dashboard; no data is persisted from the modal (read-only)
+
+### Requirement: Card detail modal SHALL offer Update price action when card has id
+
+The system SHALL display an "Update price" action (e.g. button) inside the card detail modal when the displayed card has a non-null id (i.e. the card is persisted in the collection). When the user triggers this action, the system SHALL request a single-card price update from the backend (e.g. POST `/api/prices/update/{card_id}`), SHALL receive a job_id in the response, and SHALL register that job with the global jobs state so it appears in the app-wide jobs bar with a label such as "Update price". The modal MAY remain open; the user SHALL see the job progress and completion in the bottom jobs bar. The action SHALL NOT be shown when the card has no id.
+
+#### Scenario: Update price button visible when card has id
+- **WHEN** the card detail modal is open with a card that has an id
+- **THEN** the modal displays an "Update price" action (e.g. button) that the user can click
+
+#### Scenario: Update price button not shown when card has no id
+- **WHEN** the card detail modal is open with a card that has no id (e.g. null or undefined)
+- **THEN** the modal does not display the "Update price" action
+
+#### Scenario: Triggering Update price starts job and shows it in jobs bar
+- **WHEN** the user clicks the "Update price" action in the modal for a card with an id
+- **THEN** the system sends a request to the backend to start a single-card price update for that card's id, receives a job_id, and adds the job to the global jobs state so it appears in the app-wide jobs bar (e.g. with label "Update price")
+
+### Requirement: System SHALL refresh displayed data when single-card Update price job completes
+
+When the single-card "Update price" job (started from the card detail modal) completes, the system SHALL refresh the following so they reflect the updated price: (1) total value and aggregate stats (e.g. Total Value, Average Price on the dashboard), (2) the price displayed in the card detail modal if the modal is still open for that same card, and (3) the card table rows so the updated price is visible in the list. The refresh SHALL occur when the job completes (e.g. when the job bar reports completion), without requiring the user to close the modal or reload the page.
+
+#### Scenario: Total value and stats refresh when Update price job completes
+- **WHEN** a single-card "Update price" job started from the card detail modal completes successfully
+- **THEN** the dashboard total value (and any other stats derived from the collection) are refreshed so they reflect the updated price
+
+#### Scenario: Modal price updates when job completes and modal still open for that card
+- **WHEN** a single-card "Update price" job completes and the card detail modal is still open for the same card that was updated
+- **THEN** the price shown in the modal is updated to the new value without the user closing or reopening the modal
+
+#### Scenario: Card table rows show updated price after job completes
+- **WHEN** a single-card "Update price" job completes
+- **THEN** the card table (list) is refreshed so the row for that card displays the updated price

--- a/openspec/specs/web-api-backend/spec.md
+++ b/openspec/specs/web-api-backend/spec.md
@@ -115,3 +115,23 @@ The system SHALL expose an endpoint (e.g. GET `/api/cards/resolve?name=<card_nam
 #### Scenario: Resolve returns 404 when card not found
 - **WHEN** client sends GET request to resolve with a name that Scryfall (and collection) cannot resolve
 - **THEN** system returns 404 (or appropriate error) so the client can show an error or allow manual retry
+
+### Requirement: Backend SHALL provide single-card price update endpoint
+
+The system SHALL provide POST `/api/prices/update/{card_id}` where `card_id` is the surrogate card id (integer). The endpoint SHALL start a background job that updates only that card's price (e.g. from Scryfall) and writes the result to the collection. The response SHALL be JSON with job_id (and optionally status/message) so the client can poll GET `/api/jobs/{job_id}` or use the existing WebSocket progress flow. The job SHALL use the same progress and completion semantics as the bulk price update job (progress events, completion summary, cancellation via POST `/api/jobs/{id}/cancel`). Single-card update jobs MAY run concurrently with each other and with the bulk POST `/api/prices/update` job; the 409 conflict SHALL apply only to concurrent bulk price update requests, not to single-card updates. If the card_id does not exist, the system SHALL return 404.
+
+#### Scenario: POST single-card price update returns job_id
+- **WHEN** client sends POST request to `/api/prices/update/{card_id}` with a valid card id
+- **THEN** system responds with status 200 and JSON containing job_id (and optionally status/message), and starts a background job that updates that card's price
+
+#### Scenario: Single-card price update job uses same progress and completion as bulk
+- **WHEN** a single-card price update job is running
+- **THEN** the job reports progress and completion via the same mechanism as the bulk price update (e.g. WebSocket progress, GET /api/jobs/{id} with status and summary when complete)
+
+#### Scenario: Single-card update returns 404 when card not found
+- **WHEN** client sends POST request to `/api/prices/update/{card_id}` and no card exists with that id
+- **THEN** system responds with status 404 and does not create a job
+
+#### Scenario: Single-card update not blocked by bulk price update
+- **WHEN** a bulk price update job is already running (POST `/api/prices/update` returned 200 and job is in progress)
+- **THEN** a client MAY successfully start a single-card price update via POST `/api/prices/update/{card_id}` and receive a job_id without receiving 409


### PR DESCRIPTION
- Add "Update price" button in card detail modal (when card has id)
- Backend: POST /api/prices/update/{card_id} for one-card price job
- Refetch stats, modal price and table when job completes (onFinished callback)
- Use english_name for Scryfall price lookup when available (bulk and single-card)
- Archive OpenSpec change card-detail-update-price and sync specs