### PR TITLE
fix: support Docker and OAuth in both local and GitHub Codespaces

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,7 @@ COPY migrations /app/migrations
 COPY config.yaml /app/config.yaml
 
 # Create logs directory
-RUN mkdir -p /app/backend/logs
+RUN mkdir -p /app/logs
 
 # Expose port
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:15-alpine
@@ -37,7 +35,7 @@ services:
       - ./backend:/app/backend:ro
       - ./deckdex:/app/deckdex:ro
       - ./config.yaml:/app/config.yaml:ro
-      - backend-logs:/app/backend/logs
+      - backend-logs:/app/logs
     env_file:
       - .env
     depends_on:

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -16,7 +16,7 @@ const Login: React.FC = () => {
 
   const handleGoogleLogin = () => {
     // Redirect to backend OAuth endpoint
-    window.location.href = 'http://localhost:8000/api/auth/google';
+    window.location.href = '/api/auth/google';
   };
 
   const error = searchParams.get('error');


### PR DESCRIPTION
- Fix backend container crash from read-only mount conflict (logs volume)
- Remove hardcoded localhost URLs from OAuth flow (auth.py, Login.tsx)
- Derive redirect URIs dynamically from request headers
- Remove obsolete docker-compose version attribute