### PR TITLE
fix: remove all hardcoded localhost:8000 from frontend OAuth redirects

### DIFF
--- a/frontend/src/components/landing/FinalCTA.tsx
+++ b/frontend/src/components/landing/FinalCTA.tsx
@@ -1,8 +1,9 @@
 import { motion } from 'framer-motion';
 import { useAuth } from '@/contexts/AuthContext';
+import { redirectToGoogleLogin } from '@/utils/auth';
 
 const handleGoogleLogin = () => {
-  window.location.href = 'http://localhost:8000/api/auth/google';
+  redirectToGoogleLogin();
 };
 
 export const FinalCTA = () => {

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -1,9 +1,10 @@
 import { motion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { redirectToGoogleLogin } from '@/utils/auth';
 
 const handleGoogleLogin = () => {
-  window.location.href = 'http://localhost:8000/api/auth/google';
+  redirectToGoogleLogin();
 };
 
 export const Hero = ({ onDemoClick }: { onDemoClick: () => void }) => {

--- a/frontend/src/components/landing/InteractiveDemo.tsx
+++ b/frontend/src/components/landing/InteractiveDemo.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Search } from 'lucide-react';
+import { redirectToGoogleLogin } from '@/utils/auth';
 
 interface DemoCard {
   id: number;
@@ -30,7 +31,7 @@ const DEMO_CARDS: DemoCard[] = [
 type RarityFilter = 'All' | 'Common' | 'Uncommon' | 'Rare' | 'Mythic';
 
 const handleGoogleLogin = () => {
-  window.location.href = 'http://localhost:8000/api/auth/google';
+  redirectToGoogleLogin();
 };
 
 export const InteractiveDemo = () => {

--- a/frontend/src/components/landing/LandingNavbar.tsx
+++ b/frontend/src/components/landing/LandingNavbar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Menu, X, Github, Sparkles } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { redirectToGoogleLogin } from '@/utils/auth';
 
 export const LandingNavbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -26,7 +27,7 @@ export const LandingNavbar = () => {
   };
 
   const handleGoogleLogin = () => {
-    window.location.href = 'http://localhost:8000/api/auth/google';
+    redirectToGoogleLogin();
   };
 
   const handleLogoClick = () => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -171,7 +171,7 @@ export function Dashboard() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 max-w-lg">
           <h1 className="text-2xl font-bold text-red-600 dark:text-red-400 mb-4">Backend Connection Error</h1>
           <p className="text-gray-700 dark:text-gray-300 mb-4">
-            Cannot connect to the backend API at http://localhost:8000. Start it in one of these ways:
+            Cannot connect to the backend API. Start it in one of these ways:
           </p>
           <div className="space-y-3 text-sm">
             <p className="font-medium text-gray-800 dark:text-gray-200">Docker (all services):</p>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { redirectToGoogleLogin } from '../utils/auth';
 
 const Login: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth();
@@ -15,18 +16,7 @@ const Login: React.FC = () => {
   }, [isAuthenticated, isLoading, navigate]);
 
   const handleGoogleLogin = () => {
-    // OAuth must go directly to the backend (not through Vite proxy) so the
-    // backend can read its own public Host header and build correct redirect URIs.
-    const { protocol, hostname } = window.location;
-    let backendOrigin: string;
-    if (hostname.includes('.app.github.dev')) {
-      // Codespaces: port is encoded in the hostname
-      backendOrigin = `${protocol}//${hostname.replace('-5173.', '-8000.')}`;
-    } else {
-      // Local dev: backend on port 8000
-      backendOrigin = `${protocol}//${hostname}:8000`;
-    }
-    window.location.href = `${backendOrigin}/api/auth/google`;
+    redirectToGoogleLogin();
   };
 
   const error = searchParams.get('error');

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,0 +1,20 @@
+/**
+ * Build the backend origin URL for OAuth redirects.
+ *
+ * OAuth must go directly to the backend (not through Vite proxy) so the
+ * backend can read its own public Host header and build correct redirect URIs.
+ */
+export function getBackendOrigin(): string {
+  const { protocol, hostname } = window.location;
+  if (hostname.includes('.app.github.dev')) {
+    // Codespaces: port is encoded in the hostname
+    return `${protocol}//${hostname.replace('-5173.', '-8000.')}`;
+  }
+  // Local dev: backend on port 8000
+  return `${protocol}//${hostname}:8000`;
+}
+
+/** Redirect the browser to the Google OAuth login endpoint on the backend. */
+export function redirectToGoogleLogin(): void {
+  window.location.href = `${getBackendOrigin()}/api/auth/google`;
+}


### PR DESCRIPTION
Extracted shared redirectToGoogleLogin() helper in utils/auth.ts that detects local vs Codespaces environment. Updated all 5 components that had hardcoded localhost:8000 OAuth URLs (Login, Hero, LandingNavbar, FinalCTA, InteractiveDemo).