### PR TITLE
fix: show Add card button even when collection is empty

### DIFF
--- a/frontend/src/components/CardTable.tsx
+++ b/frontend/src/components/CardTable.tsx
@@ -9,7 +9,6 @@ interface CardTableProps {
 }
 
 export function CardTable({ cards, isLoading, onAdd, onRowClick }: CardTableProps) {
-  const hasIds = cards.some(c => c.id != null);
   const [sortKey, setSortKey] = useState<string>('created_at');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [currentPage, setCurrentPage] = useState(1);
@@ -131,7 +130,7 @@ export function CardTable({ cards, isLoading, onAdd, onRowClick }: CardTableProp
 
   return (
     <div ref={containerRef} className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
-      {onAdd && hasIds && (
+      {onAdd && (
         <div className="px-6 py-3 border-b border-gray-200 dark:border-gray-600">
           <button
             type="button"


### PR DESCRIPTION
The button was gated on hasIds (at least one card with an ID), creating a catch-22 where you couldn't add cards to an empty collection.