### PR TITLE
feat: deck features — card allocation, mobile UX, power level estimation

### DIFF
--- a/backend/api/routes/cards.py
+++ b/backend/api/routes/cards.py
@@ -10,7 +10,15 @@ from fastapi.responses import FileResponse
 from loguru import logger
 from pydantic import BaseModel
 
-from ..dependencies import clear_collection_cache, get_cached_collection, get_collection_repo, get_current_user_id
+from deckdex.storage.deck_repository import DeckRepository
+
+from ..dependencies import (
+    clear_collection_cache,
+    get_cached_collection,
+    get_collection_repo,
+    get_current_user_id,
+    get_deck_repo,
+)
 from ..filters import filter_collection
 from ..main import limiter
 from ..services.card_image_service import get_card_image_path
@@ -90,6 +98,25 @@ class PriceHistoryResponse(BaseModel):
     card_id: int
     currency: str
     points: List[PriceHistoryPoint]
+
+
+class DeckRef(BaseModel):
+    deck_id: int
+    deck_name: str
+
+
+class CardAllocation(BaseModel):
+    card_id: int
+    card_name: str
+    image_url: Optional[str] = None
+    type_line: Optional[str] = None
+    mana_cost: Optional[str] = None
+    quantity: int
+    decks: List[DeckRef]
+
+
+class CardAllocationsResponse(BaseModel):
+    cards: List[CardAllocation]
 
 
 # ---------------------------------------------------------------------------
@@ -276,6 +303,55 @@ async def list_cards(
             )
 
         raise HTTPException(status_code=500, detail="Failed to fetch cards")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/cards/allocations  (must be before /{id} wildcard routes)
+# ---------------------------------------------------------------------------
+
+
+def _require_deck_repo_for_allocations():
+    """Guard: returns DeckRepository or raises 501 when Postgres is not configured."""
+    repo = get_deck_repo()
+    if repo is None:
+        raise HTTPException(
+            status_code=501,
+            detail="Allocations require Postgres. Set DATABASE_URL to use deck features.",
+        )
+    return repo
+
+
+@router.get("/allocations", response_model=CardAllocationsResponse)
+async def get_card_allocations(
+    user_id: int = Depends(get_current_user_id),
+    repo: DeckRepository = Depends(_require_deck_repo_for_allocations),
+):
+    """Return all collection cards with their deck assignment lists.
+
+    Each card appears once in the response; its `decks` list is empty when it
+    is not assigned to any deck (status: available).
+    Requires PostgreSQL. Returns 501 when DATABASE_URL is not set.
+    """
+    rows = repo.get_all_card_allocations(user_id=user_id)
+
+    # Aggregate flat (card, deck) rows into per-card structure
+    seen: Dict[int, CardAllocation] = {}
+    for row in rows:
+        cid = row["card_id"]
+        if cid not in seen:
+            seen[cid] = CardAllocation(
+                card_id=cid,
+                card_name=row["card_name"] or "",
+                image_url=row.get("image_url"),
+                type_line=row.get("type_line"),
+                mana_cost=row.get("mana_cost"),
+                quantity=row.get("quantity") or 1,
+                decks=[],
+            )
+        if row.get("deck_id") is not None:
+            seen[cid].decks.append(DeckRef(deck_id=row["deck_id"], deck_name=row["deck_name"]))
+
+    return CardAllocationsResponse(cards=list(seen.values()))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/routes/decks.py
+++ b/backend/api/routes/decks.py
@@ -74,6 +74,22 @@ class BatchAddResult(BaseModel):
     deck: Dict[str, Any]
 
 
+class PowerLevelBreakdownResponse(BaseModel):
+    fast_mana: float
+    tutors: float
+    combo_pieces: float
+    avg_cmc: float
+    land_quality: float
+    staple_density: float
+
+
+class PowerLevelResponse(BaseModel):
+    score: float
+    bracket: int
+    summary: str
+    breakdown: PowerLevelBreakdownResponse
+
+
 # --- Routes ---
 
 
@@ -271,3 +287,18 @@ async def import_deck_text(
         skipped=skipped,
         deck=updated_deck,
     )
+
+
+@router.get("/{deck_id}/power-level", response_model=PowerLevelResponse)
+async def get_deck_power_level(
+    deck_id: int,
+    repo: DeckRepository = Depends(require_deck_repo),
+    user_id: int = Depends(get_current_user_id),
+):
+    """Return heuristic power level score and Commander Bracket for a deck."""
+    from ..services.power_level_service import get_power_level
+
+    result = get_power_level(deck_id, repo, user_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    return result

--- a/backend/api/services/power_level_service.py
+++ b/backend/api/services/power_level_service.py
@@ -1,0 +1,43 @@
+"""Caching service layer for deck power level estimation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from deckdex.services.power_level import PowerLevelResult, estimate_power_level
+from deckdex.storage.deck_repository import DeckRepository
+
+_cache: dict[tuple, tuple[PowerLevelResult, datetime]] = {}
+_CACHE_TTL_SECONDS = 300
+
+
+def _cache_key(deck: dict, user_id: int) -> tuple:
+    return (
+        deck["id"],
+        user_id,
+        len(deck.get("cards", [])),
+        deck.get("updated_at", ""),
+    )
+
+
+def get_power_level(deck_id: int, repo: DeckRepository, user_id: int) -> Optional[PowerLevelResult]:
+    """Return cached or freshly computed power level for a deck.
+
+    Returns None if the deck does not exist or does not belong to the user.
+    """
+    deck = repo.get_deck_with_cards(deck_id, user_id=user_id)
+    if deck is None:
+        return None
+
+    key = _cache_key(deck, user_id)
+    now = datetime.now(tz=timezone.utc)
+
+    if key in _cache:
+        result, cached_at = _cache[key]
+        if (now - cached_at).total_seconds() < _CACHE_TTL_SECONDS:
+            return result
+
+    result = estimate_power_level(deck.get("cards", []))
+    _cache[key] = (result, now)
+    return result

--- a/deckdex/services/power_level.py
+++ b/deckdex/services/power_level.py
@@ -1,0 +1,317 @@
+"""
+Heuristic power level estimation for Commander decks.
+
+Pure computation — no I/O, no database access.
+Input: list of card dicts as returned by DeckRepository.get_deck_with_cards() → deck["cards"]
+  Relevant keys: name, description (oracle text), type (type_line), cmc, edhrec_rank, quantity, is_commander
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Curated card sets (all lowercase)
+# ---------------------------------------------------------------------------
+
+FAST_MANA: frozenset[str] = frozenset(
+    {
+        "sol ring",
+        "mana crypt",
+        "mana vault",
+        "chrome mox",
+        "mox diamond",
+        "mox opal",
+        "lotus petal",
+        "dark ritual",
+        "cabal ritual",
+        "elvish spirit guide",
+        "simian spirit guide",
+        "ancient tomb",
+        "gaea's cradle",
+        "serra's sanctum",
+        "mishra's workshop",
+        "jeweled lotus",
+        "lotus bloom",
+        "mox amber",
+        "mana drain",
+        "dockside extortionist",
+        "vault of whispers",
+        "seat of the synod",
+        "tree of tales",
+        "great furnace",
+        "ancient den",
+        "darksteel citadel",
+    }
+)
+
+COMBO_PIECES: frozenset[str] = frozenset(
+    {
+        "thassa's oracle",
+        "demonic consultation",
+        "tainted pact",
+        "laboratory maniac",
+        "jace, wielder of mysteries",
+        "isochron scepter",
+        "dramatic reversal",
+        "staff of domination",
+        "umbral mantle",
+        "sword of the paruns",
+        "basalt monolith",
+        "rings of brighthearth",
+        "splinter twin",
+        "kiki-jiki, mirror breaker",
+        "devoted druid",
+        "vizier of remedies",
+        "heliod, sun-crowned",
+        "walking ballista",
+        "necropotence",
+        "ad nauseam",
+    }
+)
+
+PREMIUM_LANDS: frozenset[str] = frozenset(
+    {
+        # Original dual lands
+        "tundra",
+        "underground sea",
+        "badlands",
+        "taiga",
+        "savannah",
+        "scrubland",
+        "volcanic island",
+        "bayou",
+        "plateau",
+        "tropical island",
+        # Shock lands
+        "hallowed fountain",
+        "watery grave",
+        "blood crypt",
+        "stomping ground",
+        "temple garden",
+        "godless shrine",
+        "steam vents",
+        "overgrown tomb",
+        "sacred foundry",
+        "breeding pool",
+        # Fetch lands (Onslaught + Zendikar cycles)
+        "flooded strand",
+        "polluted delta",
+        "bloodstained mire",
+        "wooded foothills",
+        "windswept heath",
+        "marsh flats",
+        "scalding tarn",
+        "verdant catacombs",
+        "arid mesa",
+        "misty rainforest",
+        # Zendikar battle lands
+        "prairie stream",
+        "sunken hollow",
+        "smoldering marsh",
+        "cinder glade",
+        "canopy vista",
+        "shambling vent",
+        "wandering fumarole",
+        "needle spires",
+        "hissing quagmire",
+        "lumbering falls",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Bracket mapping
+# ---------------------------------------------------------------------------
+
+_BRACKET_THRESHOLDS = [(8.0, 4), (6.0, 3), (4.0, 2)]
+
+
+def _compute_bracket(score: float) -> int:
+    for threshold, bracket in _BRACKET_THRESHOLDS:
+        if score >= threshold:
+            return bracket
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class FactorBreakdown(BaseModel):
+    fast_mana: float
+    tutors: float
+    combo_pieces: float
+    avg_cmc: float
+    land_quality: float
+    staple_density: float
+
+
+class PowerLevelResult(BaseModel):
+    score: float
+    bracket: int
+    summary: str
+    breakdown: FactorBreakdown
+
+
+# ---------------------------------------------------------------------------
+# Individual signal scorers
+# ---------------------------------------------------------------------------
+
+
+def _score_fast_mana(cards: list[dict[str, Any]]) -> float:
+    count = sum(1 for c in cards if str(c.get("name", "")).lower() in FAST_MANA)
+    return min(count / 4.0, 1.0)
+
+
+def _score_tutors(cards: list[dict[str, Any]]) -> float:
+    count = sum(1 for c in cards if "search your library" in str(c.get("description", "")).lower())
+    return min(count / 5.0, 1.0)
+
+
+def _score_combo_pieces(cards: list[dict[str, Any]]) -> float:
+    count = sum(
+        1
+        for c in cards
+        if (str(c.get("name", "")).lower() in COMBO_PIECES or "infinite" in str(c.get("description", "")).lower())
+    )
+    return min(count / 3.0, 1.0)
+
+
+def _score_avg_cmc(cards: list[dict[str, Any]]) -> float:
+    non_lands = [c for c in cards if "land" not in str(c.get("type", "")).lower()]
+    if not non_lands:
+        return 0.5
+    total_cmc = sum(float(c.get("cmc") or 0) * int(c.get("quantity") or 1) for c in non_lands)
+    count = sum(int(c.get("quantity") or 1) for c in non_lands)
+    avg = total_cmc / count if count > 0 else 3.5
+    if avg <= 1.5:
+        return 1.0
+    elif avg <= 2.0:
+        return 0.85
+    elif avg <= 2.5:
+        return 0.70
+    elif avg <= 3.0:
+        return 0.55
+    elif avg <= 3.5:
+        return 0.40
+    elif avg <= 4.0:
+        return 0.25
+    else:
+        return 0.10
+
+
+def _score_land_quality(cards: list[dict[str, Any]]) -> float:
+    count = sum(1 for c in cards if str(c.get("name", "")).lower() in PREMIUM_LANDS)
+    return min(count / 10.0, 1.0)
+
+
+def _score_staple_density(cards: list[dict[str, Any]]) -> float:
+    """Cards with EDHREC rank <= 50 are considered high-impact staples."""
+    count = 0
+    for c in cards:
+        rank = c.get("edhrec_rank")
+        if rank is not None:
+            try:
+                if int(rank) <= 50:
+                    count += 1
+            except (ValueError, TypeError):
+                pass
+    return min(count / 10.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Summary string builder
+# ---------------------------------------------------------------------------
+
+_POWER_ADJECTIVES = {
+    (1, 3): "casual",
+    (4, 5): "mid-power",
+    (6, 7): "strong",
+    (8, 10): "highly optimised",
+}
+
+_FACTOR_LABELS = {
+    "fast_mana": "fast mana",
+    "tutors": "tutors",
+    "combo_pieces": "combo pieces",
+    "avg_cmc": "low curve",
+    "land_quality": "premium mana base",
+    "staple_density": "high-impact staples",
+}
+
+
+def _build_summary(score: float, breakdown: FactorBreakdown) -> str:
+    score_int = round(score)
+    adjective = "mid-power"
+    for (lo, hi), adj in _POWER_ADJECTIVES.items():
+        if lo <= score_int <= hi:
+            adjective = adj
+            break
+
+    scores_dict = breakdown.model_dump()
+    positives = [_FACTOR_LABELS[k] for k, v in scores_dict.items() if v >= 0.7]
+    absences = [_FACTOR_LABELS[k] for k, v in scores_dict.items() if v == 0.0]
+
+    parts = [f"{score_int} \u2014 {adjective} deck"]
+    if positives:
+        parts.append(f"with {', '.join(positives[:2])}")
+    if absences:
+        parts.append(f"but no {absences[0]}")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+_WEIGHTS = {
+    "fast_mana": 2.5,
+    "tutors": 2.0,
+    "combo_pieces": 2.0,
+    "avg_cmc": 1.5,
+    "land_quality": 1.0,
+    "staple_density": 1.0,
+}
+_TOTAL_WEIGHT = sum(_WEIGHTS.values())  # 10.0
+
+
+def estimate_power_level(cards: list[dict[str, Any]]) -> PowerLevelResult:
+    """Compute a heuristic power level score for a Commander deck.
+
+    Args:
+        cards: List of card dicts from DeckRepository.get_deck_with_cards().
+               Keys used: name, description, type, cmc, edhrec_rank, quantity.
+
+    Returns:
+        PowerLevelResult with score (1–10), bracket (1–4), summary, and breakdown.
+    """
+    if not cards:
+        breakdown = FactorBreakdown(
+            fast_mana=0.0,
+            tutors=0.0,
+            combo_pieces=0.0,
+            avg_cmc=0.5,
+            land_quality=0.0,
+            staple_density=0.0,
+        )
+        return PowerLevelResult(score=1.0, bracket=1, summary="1 \u2014 no cards in deck", breakdown=breakdown)
+
+    breakdown = FactorBreakdown(
+        fast_mana=_score_fast_mana(cards),
+        tutors=_score_tutors(cards),
+        combo_pieces=_score_combo_pieces(cards),
+        avg_cmc=_score_avg_cmc(cards),
+        land_quality=_score_land_quality(cards),
+        staple_density=_score_staple_density(cards),
+    )
+
+    scores_dict = breakdown.model_dump()
+    raw = sum(_WEIGHTS[k] * scores_dict[k] for k in _WEIGHTS) / _TOTAL_WEIGHT
+    score = round(max(1.0, min(10.0, raw * 10)), 1)
+    bracket = _compute_bracket(score)
+    summary = _build_summary(score, breakdown)
+
+    return PowerLevelResult(score=score, bracket=bracket, summary=summary, breakdown=breakdown)

--- a/deckdex/storage/deck_repository.py
+++ b/deckdex/storage/deck_repository.py
@@ -221,6 +221,10 @@ class DeckRepository:
                 """),
                 {"deck_id": deck_id, "card_id": card_id, "quantity": quantity, "is_commander": is_commander},
             )
+            conn.execute(
+                text("UPDATE decks SET updated_at = NOW() AT TIME ZONE 'utc' WHERE id = :deck_id"),
+                {"deck_id": deck_id},
+            )
             conn.commit()
         return True
 
@@ -241,6 +245,11 @@ class DeckRepository:
                 text("DELETE FROM deck_cards WHERE deck_id = :deck_id AND card_id = :card_id"),
                 {"deck_id": deck_id, "card_id": card_id},
             )
+            if result.rowcount > 0:
+                conn.execute(
+                    text("UPDATE decks SET updated_at = NOW() AT TIME ZONE 'utc' WHERE id = :deck_id"),
+                    {"deck_id": deck_id},
+                )
             conn.commit()
             return result.rowcount > 0
 
@@ -293,6 +302,10 @@ class DeckRepository:
                     {"deck_id": deck_id, "card_id": cid},
                 )
             if valid_ids:
+                conn.execute(
+                    text("UPDATE decks SET updated_at = NOW() AT TIME ZONE 'utc' WHERE id = :deck_id"),
+                    {"deck_id": deck_id},
+                )
                 conn.commit()
 
         return {"added": sorted(list(valid_ids)), "not_found": not_found}
@@ -344,6 +357,35 @@ class DeckRepository:
                 result[key] = row["id"]
         return result
 
+    def get_all_card_allocations(self, user_id: int) -> List[Dict[str, Any]]:
+        """Return all cards for user with their deck assignments.
+
+        Returns a flat list of rows: one row per (card, deck) pair.
+        Cards in no deck appear once with deck_id=None, deck_name=None.
+        """
+        from sqlalchemy import text
+
+        sql = """
+            SELECT
+                c.id        AS card_id,
+                c.name      AS card_name,
+                c.image_url,
+                c.type_line,
+                c.mana_cost,
+                c.quantity,
+                d.id        AS deck_id,
+                d.name      AS deck_name
+            FROM cards c
+            LEFT JOIN deck_cards dc ON dc.card_id = c.id
+            LEFT JOIN decks d       ON d.id = dc.deck_id AND d.user_id = :user_id
+            WHERE c.user_id = :user_id
+            ORDER BY c.name ASC
+        """
+        engine = self._get_engine()
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), {"user_id": user_id}).mappings().fetchall()
+        return [dict(row) for row in rows]
+
     def set_commander(self, deck_id: int, card_id: int, user_id: Optional[int] = None) -> bool:
         """Set one card as commander; unset any other commander in this deck. Card must be in deck."""
         from sqlalchemy import text
@@ -374,6 +416,10 @@ class DeckRepository:
                     WHERE deck_id = :deck_id AND card_id = :card_id
                 """),
                 {"deck_id": deck_id, "card_id": card_id},
+            )
+            conn.execute(
+                text("UPDATE decks SET updated_at = NOW() AT TIME ZONE 'utc' WHERE id = :deck_id"),
+                {"deck_id": deck_id},
             )
             conn.commit()
         return True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { Dashboard } from './pages/Dashboard'
 import { Settings } from './pages/Settings'
 import { Analytics } from './pages/Analytics'
 import { DeckBuilder } from './pages/DeckBuilder'
+import { CardAllocations } from './pages/CardAllocations'
 import Login from './pages/Login'
 import AuthCallback from './pages/AuthCallback'
 import ProtectedRoute from './components/ProtectedRoute'
@@ -77,6 +78,14 @@ function AppContent() {
           element={
             <ProtectedRoute>
               <DeckBuilder />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/allocations"
+          element={
+            <ProtectedRoute>
+              <CardAllocations />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -186,6 +186,41 @@ export interface BatchAddResult {
   deck: DeckWithCards;
 }
 
+export interface DeckRef {
+  deck_id: number;
+  deck_name: string;
+}
+
+export interface CardAllocation {
+  card_id: number;
+  card_name: string;
+  image_url: string | null;
+  type_line: string | null;
+  mana_cost: string | null;
+  quantity: number;
+  decks: DeckRef[];
+}
+
+export interface CardAllocationsResponse {
+  cards: CardAllocation[];
+}
+
+export interface PowerLevelBreakdown {
+  fast_mana: number;
+  tutors: number;
+  combo_pieces: number;
+  avg_cmc: number;
+  land_quality: number;
+  staple_density: number;
+}
+
+export interface PowerLevelResponse {
+  score: number;
+  bracket: number;
+  summary: string;
+  breakdown: PowerLevelBreakdown;
+}
+
 export interface ProfileUpdateBody {
   display_name?: string;
   avatar_url?: string;
@@ -833,6 +868,17 @@ export const api = {
     return response.json();
   },
 
+  getDeckPowerLevel: async (deckId: number): Promise<PowerLevelResponse> => {
+    const response = await apiFetch(`${API_BASE}/decks/${deckId}/power-level`);
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      if (response.status === 404) throw new Error('Deck not found');
+      if (response.status === 501) throw new Error((err as { detail?: string }).detail || 'Decks require Postgres');
+      throw new Error((err as { detail?: string }).detail || 'Failed to fetch power level');
+    }
+    return response.json();
+  },
+
   // Insights
   getInsightsCatalog: async (): Promise<InsightCatalogEntry[]> => {
     const response = await apiFetch(`${API_BASE}/insights/catalog`);
@@ -891,5 +937,12 @@ export const api = {
       throw new Error((err as { detail?: string }).detail || 'Failed to update profile');
     }
     return response.json();
+  },
+
+  // Card allocations — requires Postgres (501 if unavailable)
+  getCardAllocations: async (): Promise<CardAllocationsResponse> => {
+    const res = await apiFetch(`${API_BASE}/cards/allocations`);
+    if (!res.ok) throw new Error(`Failed to fetch allocations: ${res.status}`);
+    return res.json();
   },
 };

--- a/frontend/src/components/AccessibleModal.tsx
+++ b/frontend/src/components/AccessibleModal.tsx
@@ -14,6 +14,11 @@ interface AccessibleModalProps {
    * the modal panel with aria-label={t('common.close')}.
    */
   showCloseButton?: boolean;
+  /**
+   * When true, the modal fills the full screen on viewports below the sm
+   * breakpoint (< 640 px). On sm and above the layout is unchanged.
+   */
+  fullScreenOnMobile?: boolean;
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -44,6 +49,7 @@ export function AccessibleModal({
   children,
   className,
   showCloseButton = false,
+  fullScreenOnMobile = false,
 }: AccessibleModalProps) {
   const { t } = useTranslation();
   const panelRef = useRef<HTMLDivElement>(null);
@@ -135,9 +141,17 @@ export function AccessibleModal({
 
   if (!isOpen) return null;
 
+  const overlayClass = fullScreenOnMobile
+    ? `fixed inset-0 bg-black/50 sm:flex sm:items-center sm:justify-center z-50 sm:p-4 ${className ?? ''}`
+    : `fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 ${className ?? ''}`;
+
+  const panelWrapperClass = fullScreenOnMobile
+    ? 'relative max-sm:w-full max-sm:h-[100dvh]'
+    : 'relative';
+
   return (
     <div
-      className={`fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 ${className ?? ''}`}
+      className={overlayClass}
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}
@@ -145,7 +159,7 @@ export function AccessibleModal({
     >
       <div
         ref={panelRef}
-        className="relative"
+        className={panelWrapperClass}
         onClick={e => e.stopPropagation()}
       >
         {showCloseButton && (

--- a/frontend/src/components/AllocationPopover.tsx
+++ b/frontend/src/components/AllocationPopover.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
+import type { CardAllocation } from '../api/client';
+
+interface AllocationPopoverProps {
+  allocation: CardAllocation;
+  onRemoveFromDeck: (deckId: number, cardId: number) => void;
+  onClose: () => void;
+}
+
+/**
+ * Popover anchored to an AllocationTile. Shows the card's deck assignments
+ * and allows removing the card from any deck.
+ *
+ * Accessibility: role="dialog", focus on close button on mount, Escape closes.
+ */
+export function AllocationPopover({ allocation, onRemoveFromDeck, onClose }: AllocationPopoverProps) {
+  const { t } = useTranslation();
+  const closeRef = useRef<HTMLButtonElement>(null);
+  // Track in-flight remove operations to show disabled state per deck
+  const [pendingDeckIds, setPendingDeckIds] = useState<Set<number>>(new Set());
+
+  // Focus the close button on mount and handle Escape key
+  useEffect(() => {
+    closeRef.current?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const handleRemove = (deckId: number) => {
+    setPendingDeckIds((prev) => new Set(prev).add(deckId));
+    onRemoveFromDeck(deckId, allocation.card_id);
+    // The parent clears selectedAllocation after success, which unmounts this
+    // component. We only clear pending state if the parent does not unmount us
+    // (e.g. on error). Keeping it disabled after a failed remove is acceptable
+    // UX — the user can close and reopen to retry.
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`${allocation.card_name} allocation details`}
+      className="absolute z-50 top-0 left-full ml-2 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-600 p-3"
+    >
+      {/* Header: card name + close button */}
+      <div className="flex items-start justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white pr-2 leading-tight">
+          {allocation.card_name}
+        </h3>
+        <button
+          ref={closeRef}
+          type="button"
+          onClick={onClose}
+          aria-label={t('allocations.close')}
+          className="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Content: either available message or deck list */}
+      {allocation.decks.length === 0 ? (
+        <p className="text-xs text-green-600 dark:text-green-400">
+          {t('allocations.available')}
+        </p>
+      ) : (
+        <>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">{t('allocations.assignedTo')}</p>
+          <ul className="space-y-1">
+            {allocation.decks.map((deck) => {
+              const isPending = pendingDeckIds.has(deck.deck_id);
+              return (
+                <li key={deck.deck_id} className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-gray-700 dark:text-gray-300 truncate">
+                    {deck.deck_name}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => handleRemove(deck.deck_id)}
+                    aria-label={t('allocations.removeFrom', { deckName: deck.deck_name })}
+                    className="flex-shrink-0 text-xs text-red-600 dark:text-red-400 hover:underline focus:outline-none focus:ring-2 focus:ring-red-500 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isPending ? t('allocations.removing') : t('allocations.remove')}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/AllocationTile.tsx
+++ b/frontend/src/components/AllocationTile.tsx
@@ -1,0 +1,94 @@
+import { useRef, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { CardAllocation } from '../api/client';
+import { useImageCache } from '../hooks/useImageCache';
+
+export type AllocationStatus = 'available' | 'assigned' | 'shared';
+
+/**
+ * Derives a card's allocation status from the number of decks it appears in.
+ * Exported for unit testing.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function getAllocationStatus(deckCount: number): AllocationStatus {
+  if (deckCount === 0) return 'available';
+  if (deckCount === 1) return 'assigned';
+  return 'shared';
+}
+
+const STATUS_COLORS: Record<AllocationStatus, string> = {
+  available: 'bg-green-500',
+  assigned: 'bg-orange-500',
+  shared: 'bg-red-500',
+};
+
+interface AllocationTileProps {
+  allocation: CardAllocation;
+  onTileClick: (allocation: CardAllocation) => void;
+}
+
+/**
+ * Renders a card image tile with a color-coded status badge indicating
+ * how many decks the card is currently assigned to.
+ *
+ * Uses IntersectionObserver for lazy loading to avoid fetching images
+ * for off-screen tiles in large collections.
+ */
+export function AllocationTile({ allocation, onTileClick }: AllocationTileProps) {
+  const { t } = useTranslation();
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLButtonElement>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    observerRef.current = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observerRef.current?.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observerRef.current.observe(el);
+
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  // Only pass cardId once element is in (or near) viewport
+  const cardId = isVisible ? allocation.card_id : null;
+  const { src } = useImageCache(cardId);
+  const status = getAllocationStatus(allocation.decks.length);
+
+  const STATUS_LABEL_KEYS: Record<AllocationStatus, string> = {
+    available: t('allocations.statusAvailable'),
+    assigned: t('allocations.statusAssigned'),
+    shared: t('allocations.statusShared'),
+  };
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={() => onTileClick(allocation)}
+      aria-label={t('allocations.tileLabel', { name: allocation.card_name, status: STATUS_LABEL_KEYS[status] })}
+      className="relative aspect-[63/88] rounded-lg overflow-hidden bg-gray-200 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 w-full"
+    >
+      {src && (
+        <img
+          src={src}
+          alt={allocation.card_name}
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+      )}
+      {/* Status badge — positioned bottom-right corner */}
+      <span
+        aria-hidden="true"
+        className={`absolute bottom-1 right-1 w-3 h-3 rounded-full border-2 border-white dark:border-gray-800 ${STATUS_COLORS[status]}`}
+      />
+    </button>
+  );
+}

--- a/frontend/src/components/DeckCardPickerModal.tsx
+++ b/frontend/src/components/DeckCardPickerModal.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import { api, Card } from '../api/client';
+import { api } from '../api/client';
+import type { Card } from '../api/client';
 import { ManaText } from './ManaText';
 import { AccessibleModal } from './AccessibleModal';
 
@@ -93,9 +94,9 @@ export function DeckCardPickerModal({ deckId, onClose, onAdded }: DeckCardPicker
   }, [deckId, selected, onAdded]);
 
   return (
-    <AccessibleModal isOpen titleId="deck-card-picker-title" onClose={onClose} className="z-[60]" showCloseButton>
+    <AccessibleModal isOpen titleId="deck-card-picker-title" onClose={onClose} className="z-[60]" showCloseButton fullScreenOnMobile>
       <div
-        className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col overflow-hidden"
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col overflow-hidden max-sm:rounded-none max-sm:max-w-none max-sm:max-h-none max-sm:h-full max-sm:w-full"
       >
         <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between gap-4">
           <h2 id="deck-card-picker-title" className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -195,7 +196,7 @@ export function DeckCardPickerModal({ deckId, onClose, onAdded }: DeckCardPicker
                   <button
                     type="button"
                     onClick={() => toggle(id)}
-                    className={`w-full flex items-center gap-2 py-2 px-3 rounded text-left ${
+                    className={`w-full flex items-center gap-2 py-3 px-3 rounded text-left ${
                       isSelected
                         ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-900 dark:text-indigo-100'
                         : 'hover:bg-gray-100 dark:hover:bg-gray-700/50 text-gray-900 dark:text-white'
@@ -229,7 +230,7 @@ export function DeckCardPickerModal({ deckId, onClose, onAdded }: DeckCardPicker
             type="button"
             onClick={handleAdd}
             disabled={selected.size === 0 || addPending}
-            className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:hover:bg-indigo-600"
+            className="w-full sm:w-auto px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:hover:bg-indigo-600"
           >
             {addPending ? t('deckCardPicker.adding') : t('deckCardPicker.addToDeck')}
           </button>

--- a/frontend/src/components/DeckDetailModal.tsx
+++ b/frontend/src/components/DeckDetailModal.tsx
@@ -5,6 +5,7 @@ import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Cell } from 'recharts
 import { api, DeckCard, DeckImportResponse } from '../api/client';
 import { formatCurrency } from './analytics/constants';
 import { useCardImage } from '../hooks/useCardImage';
+import { useSwipeToRemove } from '../hooks/useSwipeToRemove';
 import { DeckCardPickerModal } from './DeckCardPickerModal';
 import { CardDetailModal } from './CardDetailModal';
 import { ConfirmModal } from './ConfirmModal';
@@ -66,6 +67,108 @@ function groupCardsBySection(cards: DeckCard[]): Map<string, DeckCard[]> {
   return map;
 }
 
+// ---------------------------------------------------------------------------
+// DeckCardRow — extracted sub-component so each row can call useSwipeToRemove
+// ---------------------------------------------------------------------------
+
+interface DeckCardRowProps {
+  card: DeckCard;
+  setCommanderPending: number | null;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  onRemove: (cardId: number) => void;
+  onSetCommander: (e: React.MouseEvent, cardId: number) => void;
+  onCardClick: (card: DeckCard) => void;
+}
+
+function DeckCardRow({
+  card,
+  setCommanderPending,
+  onMouseEnter,
+  onMouseLeave,
+  onRemove,
+  onSetCommander,
+  onCardClick,
+}: DeckCardRowProps) {
+  const { t } = useTranslation();
+  const qty = card.quantity ?? 1;
+  const showSetCommander =
+    isLegendaryCreature(card) && !card.is_commander && card.id != null;
+
+  const { containerProps, translateX, animatingBack, isRevealed } = useSwipeToRemove(
+    () => card.id != null && onRemove(card.id),
+  );
+
+  return (
+    <li
+      key={card.id}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className="relative overflow-hidden rounded"
+      {...containerProps}
+    >
+      {/* Red swipe strip — revealed on left-swipe */}
+      <div
+        className={`absolute right-0 inset-y-0 w-[72px] flex items-center justify-center text-white text-xs font-bold rounded-r bg-red-500 transition-opacity ${isRevealed ? 'opacity-100' : 'opacity-0'}`}
+        aria-hidden="true"
+      >
+        Remove
+      </div>
+      {/* Row content — translates left on swipe */}
+      <div
+        className="flex items-center gap-2 py-2.5 px-2 hover:bg-gray-100 dark:hover:bg-gray-700/50 group"
+        style={{
+          transform: `translateX(${translateX}px)`,
+          transition: animatingBack ? 'transform 200ms' : undefined,
+        }}
+      >
+        <span className="w-6 text-right text-gray-500 dark:text-gray-400 text-sm tabular-nums flex-shrink-0">
+          {qty}
+        </span>
+        <button
+          type="button"
+          onClick={() => card && onCardClick(card)}
+          className="flex-1 min-w-0 text-left truncate text-gray-900 dark:text-white hover:underline"
+        >
+          {card.name}
+        </button>
+        {card.mana_cost && (
+          <span className="flex-shrink-0 card-symbols-inline">
+            <ManaText text={card.mana_cost} className="text-sm" />
+          </span>
+        )}
+        {showSetCommander && (
+          <button
+            type="button"
+            onClick={(e) => card.id != null && onSetCommander(e, card.id)}
+            disabled={setCommanderPending === card.id}
+            className="flex-shrink-0 px-2 py-0.5 text-xs rounded bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 hover:bg-amber-200 dark:hover:bg-amber-800/50 disabled:opacity-50"
+          >
+            {setCommanderPending === card.id ? '…' : t('deckDetail.setAsCommander')}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (card.id != null) onRemove(card.id);
+          }}
+          className="sm:opacity-0 sm:group-hover:opacity-100 text-red-600 hover:text-red-700 dark:text-red-400 p-3 sm:p-1 rounded flex-shrink-0"
+          aria-label={`Remove ${card.name}`}
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DeckDetailModal
+// ---------------------------------------------------------------------------
+
 interface DeckDetailModalProps {
   deckId: number;
   onClose: () => void;
@@ -78,6 +181,24 @@ export function DeckDetailModal({ deckId, onClose, onDeleted }: DeckDetailModalP
   const [pickerOpen, setPickerOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState(false);
+
+  const { data: powerLevel } = useQuery({
+    queryKey: ['deckPowerLevel', deckId],
+    queryFn: () => api.getDeckPowerLevel(deckId),
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const BRACKET_LABELS: Record<number, string> = {
+    1: 'Casual', 2: 'Mid Power', 3: 'High Power', 4: 'Optimised',
+  };
+  const bracketTextColor = (b: number): string => {
+    if (b === 1) return 'text-green-500';
+    if (b === 2) return 'text-blue-500';
+    if (b === 3) return 'text-orange-500';
+    return 'text-red-500';
+  };
+
   const [deleteDeckConfirmOpen, setDeleteDeckConfirmOpen] = useState(false);
   const [hoverCardId, setHoverCardId] = useState<number | null>(null);
   const [detailCard, setDetailCard] = useState<DeckCard | null>(null);
@@ -261,9 +382,9 @@ export function DeckDetailModal({ deckId, onClose, onDeleted }: DeckDetailModalP
 
   return (
     <>
-      <AccessibleModal isOpen titleId="deck-detail-modal-title" onClose={onClose} className="z-50">
+      <AccessibleModal isOpen titleId="deck-detail-modal-title" onClose={onClose} className="z-50" fullScreenOnMobile>
         <div
-          className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col overflow-hidden"
+          className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col overflow-hidden max-sm:rounded-none max-sm:max-w-none max-sm:max-h-none max-sm:h-full"
         >
           <div className="border-b border-gray-200 dark:border-gray-700 p-4">
             <div className="flex flex-wrap items-center gap-3 sm:gap-4">
@@ -345,8 +466,22 @@ export function DeckDetailModal({ deckId, onClose, onDeleted }: DeckDetailModalP
                   CMC {filterByCmc === 7 ? '7+' : filterByCmc} ×
                 </button>
               )}
-              {/* Buttons */}
-              <div className="flex items-center gap-2 shrink-0 ml-auto">
+              {/* Power level */}
+              {powerLevel && (
+                <div
+                  className="flex flex-col items-center shrink-0 cursor-help px-2"
+                  title={powerLevel.summary}
+                >
+                  <span className={`text-lg font-bold leading-none ${bracketTextColor(powerLevel.bracket)}`}>
+                    {powerLevel.score.toFixed(1)}
+                  </span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap mt-0.5">
+                    {BRACKET_LABELS[powerLevel.bracket]} · B{powerLevel.bracket}
+                  </span>
+                </div>
+              )}
+              {/* Desktop header action buttons — hidden on mobile (replaced by sticky bar) */}
+              <div className="hidden md:flex items-center gap-2 shrink-0 ml-auto">
                 <button
                   type="button"
                   onClick={handleExport}
@@ -380,7 +515,8 @@ export function DeckDetailModal({ deckId, onClose, onDeleted }: DeckDetailModalP
           </div>
 
           <div className="flex flex-1 overflow-hidden min-h-0">
-            <div className="w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center justify-start bg-gray-50 dark:bg-gray-900/50 p-4 overflow-visible">
+            {/* Left image panel — hidden on mobile */}
+            <div className="hidden md:flex w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 flex-col items-center justify-start bg-gray-50 dark:bg-gray-900/50 p-4 overflow-visible">
               {bigImageUrl ? (
                 <>
                   <div
@@ -420,62 +556,57 @@ export function DeckDetailModal({ deckId, onClose, onDeleted }: DeckDetailModalP
                     {title} ({sectionCards.length})
                   </h3>
                   <ul className="space-y-1">
-                    {sectionCards.map((card) => {
-                      const qty = card.quantity ?? 1;
-                      const showSetCommander =
-                        isLegendaryCreature(card) && !card.is_commander && card.id != null;
-                      return (
-                        <li
-                          key={card.id}
-                          onMouseEnter={() => card.id != null && setHoverCardId(card.id)}
-                          onMouseLeave={() => setHoverCardId(null)}
-                          className="flex items-center gap-2 py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700/50 group"
-                        >
-                          <span className="w-6 text-right text-gray-500 dark:text-gray-400 text-sm tabular-nums flex-shrink-0">
-                            {qty}
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => card && setDetailCard(card)}
-                            className="flex-1 min-w-0 text-left truncate text-gray-900 dark:text-white hover:underline"
-                          >
-                            {card.name}
-                          </button>
-                          {card.mana_cost && (
-                            <span className="flex-shrink-0 card-symbols-inline">
-                              <ManaText text={card.mana_cost} className="text-sm" />
-                            </span>
-                          )}
-                          {showSetCommander && (
-                            <button
-                              type="button"
-                              onClick={(e) => card.id != null && handleSetCommander(e, card.id)}
-                              disabled={setCommanderPending === card.id}
-                              className="flex-shrink-0 px-2 py-0.5 text-xs rounded bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 hover:bg-amber-200 dark:hover:bg-amber-800/50 disabled:opacity-50"
-                            >
-                              {setCommanderPending === card.id ? '…' : t('deckDetail.setAsCommander')}
-                            </button>
-                          )}
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (card.id != null) handleRemoveCard(card.id);
-                            }}
-                            className="opacity-0 group-hover:opacity-100 text-red-600 hover:text-red-700 dark:text-red-400 p-1 rounded flex-shrink-0"
-                            aria-label={`Remove ${card.name}`}
-                          >
-                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                          </button>
-                        </li>
-                      );
-                    })}
+                    {sectionCards.map((card) => (
+                      <DeckCardRow
+                        key={card.id}
+                        card={card}
+                        setCommanderPending={setCommanderPending}
+                        onMouseEnter={() => card.id != null && setHoverCardId(card.id)}
+                        onMouseLeave={() => setHoverCardId(null)}
+                        onRemove={handleRemoveCard}
+                        onSetCommander={handleSetCommander}
+                        onCardClick={setDetailCard}
+                      />
+                    ))}
                   </ul>
                 </div>
               ))}
             </div>
+          </div>
+
+          {/* Mobile sticky action bar — hidden on md and above */}
+          <div
+            className="md:hidden sticky bottom-0 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 flex"
+            style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+          >
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              className="flex-1 flex items-center justify-center gap-1 py-3 text-sm font-medium text-indigo-600 dark:text-indigo-400"
+            >
+              {t('deckDetail.mobileActions.addCard')}
+            </button>
+            <button
+              type="button"
+              onClick={handleExport}
+              className="flex-1 flex items-center justify-center gap-1 py-3 text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {t('deckDetail.mobileActions.export')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setImportOpen(true)}
+              className="flex-1 flex items-center justify-center gap-1 py-3 text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {t('deckDetail.mobileActions.import')}
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="flex-1 flex items-center justify-center gap-1 py-3 text-sm font-medium text-red-600 dark:text-red-400"
+            >
+              {t('deckDetail.mobileActions.deleteDeck')}
+            </button>
           </div>
         </div>
       </AccessibleModal>

--- a/frontend/src/components/DeckImportModal.tsx
+++ b/frontend/src/components/DeckImportModal.tsx
@@ -33,9 +33,9 @@ export function DeckImportModal({ deckId, onClose, onImported }: DeckImportModal
   }, [onClose]);
 
   return (
-    <AccessibleModal isOpen titleId="deck-import-modal-title" onClose={onClose} className="z-[70]" showCloseButton>
+    <AccessibleModal isOpen titleId="deck-import-modal-title" onClose={onClose} className="z-[70]" showCloseButton fullScreenOnMobile>
       <div
-        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden"
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden max-sm:rounded-none max-sm:max-w-none max-sm:h-full"
       >
         {/* Header */}
         <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-4">
@@ -45,7 +45,7 @@ export function DeckImportModal({ deckId, onClose, onImported }: DeckImportModal
         </div>
 
         {/* Body */}
-        <div className="px-6 py-4 flex flex-col gap-4">
+        <div className="px-6 py-4 flex flex-col gap-4 flex-1">
           {result === null ? (
             <>
               <label
@@ -56,7 +56,7 @@ export function DeckImportModal({ deckId, onClose, onImported }: DeckImportModal
               </label>
               <textarea
                 id="deck-import-textarea"
-                className="w-full h-48 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono placeholder:text-gray-400 dark:placeholder:text-gray-500"
+                className="w-full sm:h-48 flex-1 min-h-[12rem] rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono placeholder:text-gray-400 dark:placeholder:text-gray-500"
                 placeholder={t('deckImport.placeholder')}
                 value={text}
                 onChange={(e) => setText(e.target.value)}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -56,6 +56,7 @@ export function Navbar() {
   const navLinks = [
     { path: '/dashboard', label: t('navbar.collection') },
     { path: '/decks', label: t('navbar.deckBuilder'), badge: 'alpha' },
+    { path: '/allocations', label: t('navbar.allocations'), badge: 'alpha' },
     { path: '/analytics', label: t('navbar.analytics'), badge: 'beta' },
     ...(user?.is_admin ? [{ path: '/admin', label: t('navbar.admin') }] : []),
   ];

--- a/frontend/src/components/__tests__/AllocationPopover.test.tsx
+++ b/frontend/src/components/__tests__/AllocationPopover.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AllocationPopover } from '../AllocationPopover';
+import type { CardAllocation } from '../../api/client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAllocation(deckCount: number): CardAllocation {
+  return {
+    card_id: 42,
+    card_name: 'Sol Ring',
+    image_url: null,
+    type_line: 'Artifact',
+    mana_cost: '{1}',
+    quantity: 1,
+    decks: Array.from({ length: deckCount }, (_, i) => ({
+      deck_id: i + 10,
+      deck_name: `Deck ${String.fromCharCode(65 + i)}`, // Deck A, Deck B, ...
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AllocationPopover', () => {
+  const onRemoveFromDeck = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onRemoveFromDeck.mockClear();
+    onClose.mockClear();
+  });
+
+  it('renders "Available — not in any deck" when decks array is empty', () => {
+    render(
+      <AllocationPopover
+        allocation={makeAllocation(0)}
+        onRemoveFromDeck={onRemoveFromDeck}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText('Available — not in any deck')).toBeInTheDocument();
+  });
+
+  it('renders deck name(s) when allocation has entries', () => {
+    render(
+      <AllocationPopover
+        allocation={makeAllocation(2)}
+        onRemoveFromDeck={onRemoveFromDeck}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText('Deck A')).toBeInTheDocument();
+    expect(screen.getByText('Deck B')).toBeInTheDocument();
+  });
+
+  it('calls onRemoveFromDeck with correct (deckId, cardId) when Remove is clicked', async () => {
+    const allocation = makeAllocation(1);
+    render(
+      <AllocationPopover
+        allocation={allocation}
+        onRemoveFromDeck={onRemoveFromDeck}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /remove from deck a/i }));
+
+    expect(onRemoveFromDeck).toHaveBeenCalledOnce();
+    expect(onRemoveFromDeck).toHaveBeenCalledWith(10, 42); // deck_id=10, card_id=42
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    render(
+      <AllocationPopover
+        allocation={makeAllocation(0)}
+        onRemoveFromDeck={onRemoveFromDeck}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape key is pressed', async () => {
+    render(
+      <AllocationPopover
+        allocation={makeAllocation(0)}
+        onRemoveFromDeck={onRemoveFromDeck}
+        onClose={onClose}
+      />,
+    );
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('has role="dialog" on the root element', () => {
+    render(
+      <AllocationPopover
+        allocation={makeAllocation(1)}
+        onRemoveFromDeck={onRemoveFromDeck}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/AllocationTile.test.tsx
+++ b/frontend/src/components/__tests__/AllocationTile.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AllocationTile, getAllocationStatus } from '../AllocationTile';
+import type { CardAllocation } from '../../api/client';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Stable src to avoid needing a real image fetch in tests
+vi.mock('../../hooks/useImageCache', () => ({
+  useImageCache: vi.fn(() => ({ src: 'mock-image-url', loading: false, error: false })),
+}));
+
+// Stub IntersectionObserver — jsdom does not implement it.
+// Must be a proper constructor (class/function) because the component uses `new IntersectionObserver(...)`.
+const mockObserve = vi.fn();
+const mockDisconnect = vi.fn();
+class MockIntersectionObserver {
+  observe = mockObserve;
+  disconnect = mockDisconnect;
+  unobserve = vi.fn();
+  constructor() {}
+}
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAllocation(deckCount: number): CardAllocation {
+  return {
+    card_id: 1,
+    card_name: 'Lightning Bolt',
+    image_url: null,
+    type_line: 'Instant',
+    mana_cost: '{R}',
+    quantity: 1,
+    decks: Array.from({ length: deckCount }, (_, i) => ({
+      deck_id: i + 1,
+      deck_name: `Deck ${i + 1}`,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getAllocationStatus unit tests
+// ---------------------------------------------------------------------------
+
+describe('getAllocationStatus', () => {
+  it('returns "available" for 0 decks', () => {
+    expect(getAllocationStatus(0)).toBe('available');
+  });
+
+  it('returns "assigned" for 1 deck', () => {
+    expect(getAllocationStatus(1)).toBe('assigned');
+  });
+
+  it('returns "shared" for 3 decks', () => {
+    expect(getAllocationStatus(3)).toBe('shared');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AllocationTile component tests
+// ---------------------------------------------------------------------------
+
+describe('AllocationTile', () => {
+  const onTileClick = vi.fn();
+
+  beforeEach(() => {
+    onTileClick.mockClear();
+  });
+
+  it('renders with green badge for "available" status (0 decks)', () => {
+    render(
+      <AllocationTile allocation={makeAllocation(0)} onTileClick={onTileClick} />,
+    );
+    const badge = screen.getByRole('button').querySelector('span[aria-hidden="true"]');
+    expect(badge?.className).toContain('bg-green-500');
+  });
+
+  it('renders with orange badge for "assigned" status (1 deck)', () => {
+    render(
+      <AllocationTile allocation={makeAllocation(1)} onTileClick={onTileClick} />,
+    );
+    const badge = screen.getByRole('button').querySelector('span[aria-hidden="true"]');
+    expect(badge?.className).toContain('bg-orange-500');
+  });
+
+  it('renders with red badge for "shared" status (2+ decks)', () => {
+    render(
+      <AllocationTile allocation={makeAllocation(2)} onTileClick={onTileClick} />,
+    );
+    const badge = screen.getByRole('button').querySelector('span[aria-hidden="true"]');
+    expect(badge?.className).toContain('bg-red-500');
+  });
+
+  it('calls onTileClick with the allocation object when clicked', async () => {
+    const allocation = makeAllocation(1);
+    render(<AllocationTile allocation={allocation} onTileClick={onTileClick} />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(onTileClick).toHaveBeenCalledOnce();
+    expect(onTileClick).toHaveBeenCalledWith(allocation);
+  });
+});

--- a/frontend/src/components/__tests__/DeckCardPickerModal.test.tsx
+++ b/frontend/src/components/__tests__/DeckCardPickerModal.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DeckCardPickerModal } from '../DeckCardPickerModal';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getCards: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderWithQuery(ui: React.ReactElement) {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>{ui}</QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DeckCardPickerModal mobile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('"Add to Deck" button has w-full class for full-width on mobile', () => {
+    renderWithQuery(
+      <DeckCardPickerModal
+        deckId={1}
+        onClose={() => {}}
+        onAdded={() => {}}
+      />,
+    );
+
+    const addBtn = screen.getByRole('button', { name: /add to deck/i });
+    expect(addBtn.className).toContain('w-full');
+  });
+});

--- a/frontend/src/components/__tests__/DeckDetailModal.test.tsx
+++ b/frontend/src/components/__tests__/DeckDetailModal.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DeckDetailModal } from '../DeckDetailModal';
@@ -74,5 +74,50 @@ describe('DeckDetailModal mana curve dark mode', () => {
 
     // It must carry dark:text-gray-200 so SVG currentColor resolves to light gray in dark mode
     expect(curveWrapper?.className).toContain('dark:text-gray-200');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile remove button visibility tests
+// ---------------------------------------------------------------------------
+
+// Import the mocked api module to allow per-test overrides
+import { api as mockApi } from '../../api/client';
+
+describe('DeckDetailModal mobile remove button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+
+    // Override getDeck to return a deck with one card so the remove button renders
+    (mockApi.getDeck as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 1,
+      name: 'Test Deck',
+      card_count: 1,
+      commander_card_id: null,
+      cards: [
+        {
+          id: 42,
+          name: 'Lightning Bolt',
+          type: 'Instant',
+          quantity: 1,
+          is_commander: false,
+        },
+      ],
+    });
+  });
+
+  it('remove button uses sm:opacity-0 sm:group-hover:opacity-100 (not unconditional opacity-0)', async () => {
+    renderWithQuery(
+      <DeckDetailModal deckId={1} onClose={() => {}} onDeleted={() => {}} />,
+    );
+
+    // Wait for the card to appear
+    const removeBtn = await screen.findByLabelText('Remove Lightning Bolt');
+    expect(removeBtn).toBeTruthy();
+
+    // The button should NOT have unconditional opacity-0 — it must be sm:opacity-0
+    expect(removeBtn.className).not.toMatch(/\bopacity-0\b(?!.*sm:)/);
+    expect(removeBtn.className).toContain('sm:opacity-0');
   });
 });

--- a/frontend/src/hooks/__tests__/useSwipeToRemove.test.ts
+++ b/frontend/src/hooks/__tests__/useSwipeToRemove.test.ts
@@ -1,0 +1,154 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { useSwipeToRemove } from '../useSwipeToRemove';
+
+// ---------------------------------------------------------------------------
+// Helpers to build synthetic PointerEvents for the hook handlers
+// ---------------------------------------------------------------------------
+
+function makePointerEvent(
+  type: string,
+  overrides: Partial<React.PointerEvent> = {},
+): React.PointerEvent {
+  return {
+    pointerType: 'touch',
+    clientX: 0,
+    clientY: 0,
+    pointerId: 1,
+    currentTarget: {
+      setPointerCapture: vi.fn(),
+    },
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as React.PointerEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSwipeToRemove', () => {
+  it('mouse pointerdown — onRemove never called, translateX stays 0', () => {
+    const onRemove = vi.fn();
+    const { result } = renderHook(() => useSwipeToRemove(onRemove));
+
+    act(() => {
+      result.current.containerProps.onPointerDown?.(
+        makePointerEvent('pointerdown', { pointerType: 'mouse', clientX: 0, clientY: 0 }),
+      );
+    });
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { pointerType: 'mouse', clientX: -80, clientY: 0 }),
+      );
+    });
+    act(() => {
+      result.current.containerProps.onPointerUp?.(
+        makePointerEvent('pointerup', { pointerType: 'mouse' }),
+      );
+    });
+
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(result.current.translateX).toBe(0);
+  });
+
+  it('touch swipe >= 72 px left then pointerup — onRemove called once', () => {
+    const onRemove = vi.fn();
+    const { result } = renderHook(() => useSwipeToRemove(onRemove));
+
+    act(() => {
+      result.current.containerProps.onPointerDown?.(
+        makePointerEvent('pointerdown', { clientX: 100, clientY: 0 }),
+      );
+    });
+    // Move enough horizontally to pass axis-lock (|dx| > |dy| * 1.5)
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { clientX: 88, clientY: 0 }), // dx = -12 > 8 px threshold
+      );
+    });
+    // Move past the 72 px threshold
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { clientX: 20, clientY: 0 }), // dx = -80
+      );
+    });
+    act(() => {
+      result.current.containerProps.onPointerUp?.(
+        makePointerEvent('pointerup'),
+      );
+    });
+
+    expect(onRemove).toHaveBeenCalledOnce();
+  });
+
+  it('touch swipe < 72 px then pointerup — onRemove not called, translateX returns to 0', () => {
+    const onRemove = vi.fn();
+    const { result } = renderHook(() => useSwipeToRemove(onRemove));
+
+    act(() => {
+      result.current.containerProps.onPointerDown?.(
+        makePointerEvent('pointerdown', { clientX: 100, clientY: 0 }),
+      );
+    });
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { clientX: 88, clientY: 0 }), // dx = -12 (axis lock)
+      );
+    });
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { clientX: 60, clientY: 0 }), // dx = -40 < threshold
+      );
+    });
+    act(() => {
+      result.current.containerProps.onPointerUp?.(
+        makePointerEvent('pointerup'),
+      );
+    });
+
+    expect(onRemove).not.toHaveBeenCalled();
+    // After pointerup, translateX resets to 0
+    expect(result.current.translateX).toBe(0);
+  });
+
+  it('more horizontal than vertical — swipe is captured (axis-lock passes)', () => {
+    const onRemove = vi.fn();
+    const { result } = renderHook(() => useSwipeToRemove(onRemove));
+
+    act(() => {
+      result.current.containerProps.onPointerDown?.(
+        makePointerEvent('pointerdown', { clientX: 100, clientY: 0 }),
+      );
+    });
+    // dx = -20, dy = -5 → |dx| > |dy| * 1.5 → horizontal lock
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { clientX: 80, clientY: 5 }),
+      );
+    });
+    // translateX should be negative (row is sliding)
+    expect(result.current.translateX).toBeLessThan(0);
+  });
+
+  it('more vertical than horizontal — swipe is NOT captured (axis-lock fails)', () => {
+    const onRemove = vi.fn();
+    const { result } = renderHook(() => useSwipeToRemove(onRemove));
+
+    act(() => {
+      result.current.containerProps.onPointerDown?.(
+        makePointerEvent('pointerdown', { clientX: 100, clientY: 0 }),
+      );
+    });
+    // dx = -5, dy = -20 → |dx| < |dy| * 1.5 → vertical lock → no translation
+    act(() => {
+      result.current.containerProps.onPointerMove?.(
+        makePointerEvent('pointermove', { clientX: 95, clientY: 20 }),
+      );
+    });
+    // translateX should remain 0 because axis-locked to vertical
+    expect(result.current.translateX).toBe(0);
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useSwipeToRemove.ts
+++ b/frontend/src/hooks/useSwipeToRemove.ts
@@ -1,0 +1,76 @@
+import { useState, useRef, useCallback } from 'react';
+
+const SWIPE_THRESHOLD = 72;
+const AXIS_LOCK_RATIO = 1.5;
+const CAPTURE_START_PX = 8;
+
+export function useSwipeToRemove(onRemove: () => void): {
+  containerProps: React.HTMLAttributes<HTMLElement>;
+  translateX: number;
+  animatingBack: boolean;
+  isRevealed: boolean;
+} {
+  const [translateX, setTranslateX] = useState(0);
+  const [animatingBack, setAnimatingBack] = useState(false);
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const tracking = useRef(false);
+  const axisLocked = useRef<'horizontal' | 'vertical' | null>(null);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return;
+    startX.current = e.clientX;
+    startY.current = e.clientY;
+    tracking.current = true;
+    axisLocked.current = null;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!tracking.current) return;
+    const dx = e.clientX - startX.current;
+    const dy = e.clientY - startY.current;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    if (axisLocked.current === null && dist > CAPTURE_START_PX) {
+      axisLocked.current =
+        Math.abs(dx) > Math.abs(dy) * AXIS_LOCK_RATIO ? 'horizontal' : 'vertical';
+    }
+
+    if (axisLocked.current !== 'horizontal') return;
+
+    if (dx < 0) {
+      setAnimatingBack(false);
+      setTranslateX(Math.max(dx, -SWIPE_THRESHOLD));
+    }
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    if (!tracking.current) return;
+    tracking.current = false;
+
+    setTranslateX((prev) => {
+      if (prev <= -SWIPE_THRESHOLD) {
+        onRemove();
+        return 0;
+      }
+      setAnimatingBack(true);
+      setTimeout(() => setAnimatingBack(false), 200);
+      return 0;
+    });
+  }, [onRemove]);
+
+  const onPointerCancel = useCallback(() => {
+    tracking.current = false;
+    setAnimatingBack(true);
+    setTranslateX(0);
+    setTimeout(() => setAnimatingBack(false), 200);
+  }, []);
+
+  return {
+    containerProps: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    translateX,
+    animatingBack,
+    isRevealed: translateX <= -36,
+  };
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -152,7 +152,13 @@
     "deleteConfirmTitle": "Delete deck",
     "deleteConfirmMessage": "Are you sure you want to delete \"{{name}}\"? This cannot be undone.",
     "deleteConfirm": "Delete",
-    "deleteCancel": "Cancel"
+    "deleteCancel": "Cancel",
+    "mobileActions": {
+      "addCard": "Add",
+      "export": "Export",
+      "import": "Import",
+      "deleteDeck": "Delete"
+    }
   },
   "deckImport": {
     "title": "Import Deck List",
@@ -592,6 +598,7 @@
     "collection": "Collection",
     "analytics": "Analytics",
     "deckBuilder": "Deck Builder",
+    "allocations": "Allocations",
     "import": "Import",
     "admin": "Admin",
     "settings": "Settings",
@@ -617,5 +624,30 @@
   "themeToggle": {
     "switchToDark": "Switch to dark mode",
     "switchToLight": "Switch to light mode"
+  },
+  "powerLevel": {
+    "badge": "B{{bracket}} · {{score}}",
+    "casual": "Casual",
+    "midPower": "Mid Power",
+    "highPower": "High Power",
+    "optimised": "Optimised",
+    "bracket": "Bracket {{bracket}}",
+    "loading": "Calculating..."
+  },
+  "allocations": {
+    "title": "Card Allocations",
+    "subtitle": "See where each card is used across your decks.",
+    "errorNoPostgres": "Deck features require a Postgres database. Set DATABASE_URL to enable card allocations.",
+    "errorGeneric": "Failed to load allocations. Please try again.",
+    "statusAvailable": "Available",
+    "statusAssigned": "In 1 deck",
+    "statusShared": "In multiple decks",
+    "tileLabel": "{{name}} — {{status}}",
+    "available": "Available — not in any deck",
+    "assignedTo": "Assigned to:",
+    "close": "Close",
+    "removeFrom": "Remove from {{deckName}}",
+    "removing": "Removing…",
+    "remove": "Remove"
   }
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -152,7 +152,13 @@
     "deleteConfirmTitle": "Eliminar mazo",
     "deleteConfirmMessage": "¿Seguro que quieres eliminar \"{{name}}\"? Esta acción no se puede deshacer.",
     "deleteConfirm": "Eliminar",
-    "deleteCancel": "Cancelar"
+    "deleteCancel": "Cancelar",
+    "mobileActions": {
+      "addCard": "Añadir",
+      "export": "Exportar",
+      "import": "Importar",
+      "deleteDeck": "Eliminar"
+    }
   },
   "deckImport": {
     "title": "Importar lista de mazo",
@@ -592,6 +598,7 @@
     "collection": "Colección",
     "analytics": "Estadísticas",
     "deckBuilder": "Constructor de mazos",
+    "allocations": "Asignaciones",
     "import": "Importar",
     "admin": "Administración",
     "settings": "Ajustes",
@@ -617,5 +624,30 @@
   "themeToggle": {
     "switchToDark": "Cambiar a modo oscuro",
     "switchToLight": "Cambiar a modo claro"
+  },
+  "powerLevel": {
+    "badge": "B{{bracket}} · {{score}}",
+    "casual": "Casual",
+    "midPower": "Poder medio",
+    "highPower": "Alto poder",
+    "optimised": "Optimizado",
+    "bracket": "Nivel {{bracket}}",
+    "loading": "Calculando..."
+  },
+  "allocations": {
+    "title": "Asignaciones de cartas",
+    "subtitle": "Consulta en qué mazos se usa cada carta de tu colección.",
+    "errorNoPostgres": "Los mazos requieren Postgres. Configura DATABASE_URL para activar las asignaciones.",
+    "errorGeneric": "Error al cargar las asignaciones. Inténtalo de nuevo.",
+    "statusAvailable": "Disponible",
+    "statusAssigned": "En 1 mazo",
+    "statusShared": "En varios mazos",
+    "tileLabel": "{{name}} — {{status}}",
+    "available": "Disponible — sin asignar a ningún mazo",
+    "assignedTo": "Asignada a:",
+    "close": "Cerrar",
+    "removeFrom": "Quitar de {{deckName}}",
+    "removing": "Quitando…",
+    "remove": "Quitar"
   }
 }

--- a/frontend/src/pages/CardAllocations.tsx
+++ b/frontend/src/pages/CardAllocations.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api/client';
+import type { CardAllocation } from '../api/client';
+import { AllocationTile } from '../components/AllocationTile';
+import { AllocationPopover } from '../components/AllocationPopover';
+
+/**
+ * Page at /allocations — shows all cards in the user's collection as a grid
+ * of image tiles, each with a color-coded badge indicating whether the card
+ * is unassigned (green), in one deck (orange), or in multiple decks (red).
+ *
+ * Clicking a tile opens a popover that lists the card's deck assignments and
+ * allows removing the card from a specific deck.
+ */
+export function CardAllocations() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<CardAllocation | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['card-allocations'],
+    queryFn: api.getCardAllocations,
+  });
+
+  const handleRemoveFromDeck = async (deckId: number, cardId: number) => {
+    try {
+      await api.removeCardFromDeck(deckId, cardId);
+      await queryClient.invalidateQueries({ queryKey: ['card-allocations'] });
+      setSelected(null);
+    } catch (err) {
+      // Surface the error inline — tile stays open so user can retry
+      console.error('Failed to remove card from deck:', err);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    const msg = error instanceof Error ? error.message : '';
+    const isNoPostgres = msg.includes('501');
+    return (
+      <div className="p-6 text-center text-gray-500 dark:text-gray-400">
+        {isNoPostgres
+          ? t('allocations.errorNoPostgres')
+          : t('allocations.errorGeneric')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      {/* Page header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t('allocations.title')}</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {t('allocations.subtitle')}
+        </p>
+      </div>
+
+      {/* Card grid */}
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+        {data?.cards.map((allocation) => (
+          <div key={allocation.card_id} className="relative">
+            <AllocationTile
+              allocation={allocation}
+              onTileClick={setSelected}
+            />
+            {selected?.card_id === allocation.card_id && (
+              <AllocationPopover
+                allocation={allocation}
+                onRemoveFromDeck={handleRemoveFromDeck}
+                onClose={() => setSelected(null)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DeckBuilder.tsx
+++ b/frontend/src/pages/DeckBuilder.tsx
@@ -6,14 +6,28 @@ import { useCardImage } from '../hooks/useCardImage';
 import { DeckDetailModal } from '../components/DeckDetailModal';
 import { ConfirmModal } from '../components/ConfirmModal';
 
+const BRACKET_COLORS: Record<number, string> = {
+  1: 'bg-green-600',
+  2: 'bg-blue-600',
+  3: 'bg-orange-500',
+  4: 'bg-red-600',
+};
+
 export function DeckCardButton({ deck, onClick }: { deck: DeckListItem; onClick: () => void }) {
   const { t } = useTranslation();
   const { src: commanderImageUrl } = useCardImage(deck.commander_card_id ?? null);
+  const { data: powerLevel } = useQuery({
+    queryKey: ['deckPowerLevel', deck.id],
+    queryFn: () => api.getDeckPowerLevel(deck.id),
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
   return (
     <button
       type="button"
       onClick={onClick}
-      className="relative flex flex-col items-stretch justify-end rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden p-4 text-left shadow-sm hover:ring-2 hover:ring-indigo-500 dark:hover:ring-indigo-400 min-h-[120px] h-full bg-gray-200 dark:bg-gray-700"
+      /* min-h-[100px] intentional: exceeds 44px WCAG touch-target minimum */
+      className="relative flex flex-col items-stretch justify-end rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden p-4 text-left shadow-sm hover:ring-2 hover:ring-indigo-500 dark:hover:ring-indigo-400 min-h-[100px] h-full bg-gray-200 dark:bg-gray-700"
     >
       {commanderImageUrl && (
         <div
@@ -47,6 +61,14 @@ export function DeckCardButton({ deck, onClick }: { deck: DeckListItem; onClick:
       >
         {t('deckBuilder.cards', { count: deck.card_count ?? 0 })}
       </span>
+      {powerLevel && (
+        <span
+          className={`absolute bottom-2 right-2 z-20 text-white text-xs font-semibold px-1.5 py-0.5 rounded ${BRACKET_COLORS[powerLevel.bracket] ?? 'bg-gray-600'}`}
+          title={powerLevel.summary}
+        >
+          B{powerLevel.bracket} · {powerLevel.score.toFixed(1)}
+        </span>
+      )}
     </button>
   );
 }
@@ -126,12 +148,13 @@ export function DeckBuilder() {
         {!decksUnavailable && !isLoading && (
           <div
             className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
-            style={{ gridAutoRows: 'minmax(120px, auto)' }}
+            style={{ gridAutoRows: 'minmax(100px, auto)' }}
           >
             <button
               type="button"
               onClick={handleAddDeck}
-              className="flex items-center justify-center rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:border-indigo-500 hover:text-indigo-600 dark:hover:border-indigo-400 dark:hover:text-indigo-300 transition-colors min-h-[120px]"
+              /* min-h-[100px] intentional: exceeds 44px WCAG touch-target minimum */
+              className="flex items-center justify-center rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:border-indigo-500 hover:text-indigo-600 dark:hover:border-indigo-400 dark:hover:text-indigo-300 transition-colors min-h-[100px]"
               aria-label={t('deckBuilder.addDeckAriaLabel')}
             >
               <span className="text-3xl font-light">+</span>

--- a/frontend/src/pages/__tests__/CardAllocations.test.tsx
+++ b/frontend/src/pages/__tests__/CardAllocations.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CardAllocations } from '../CardAllocations';
+import type { CardAllocationsResponse } from '../../api/client';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetCardAllocations = vi.fn<[], Promise<CardAllocationsResponse>>();
+const mockRemoveCardFromDeck = vi.fn<[number, number], Promise<void>>();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getCardAllocations: (...args: unknown[]) => mockGetCardAllocations(...(args as [])),
+    removeCardFromDeck: (...args: unknown[]) =>
+      mockRemoveCardFromDeck(...(args as [number, number])),
+  },
+}));
+
+// Stable src avoids needing a real image in tests; also eliminates IntersectionObserver
+vi.mock('../../hooks/useImageCache', () => ({
+  useImageCache: vi.fn(() => ({ src: 'mock-image-url', loading: false, error: false })),
+}));
+
+// Stub IntersectionObserver — not available in jsdom.
+// Must be a proper constructor because AllocationTile uses `new IntersectionObserver(...)`.
+const mockObserve = vi.fn();
+class MockIntersectionObserver {
+  observe = mockObserve;
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  constructor() {}
+}
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderWithQuery(ui: React.ReactElement) {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>{ui}</QueryClientProvider>,
+  );
+}
+
+const SAMPLE_RESPONSE: CardAllocationsResponse = {
+  cards: [
+    {
+      card_id: 1,
+      card_name: 'Lightning Bolt',
+      image_url: null,
+      type_line: 'Instant',
+      mana_cost: '{R}',
+      quantity: 2,
+      decks: [],
+    },
+    {
+      card_id: 2,
+      card_name: 'Sol Ring',
+      image_url: null,
+      type_line: 'Artifact',
+      mana_cost: '{1}',
+      quantity: 1,
+      decks: [{ deck_id: 10, deck_name: 'Commander Deck' }],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CardAllocations page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading spinner while the query is in-flight', () => {
+    // Never resolves — keeps the component in loading state
+    mockGetCardAllocations.mockReturnValue(new Promise(() => {}));
+
+    renderWithQuery(<CardAllocations />);
+
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('renders the correct number of tiles after data loads', async () => {
+    mockGetCardAllocations.mockResolvedValue(SAMPLE_RESPONSE);
+
+    renderWithQuery(<CardAllocations />);
+
+    await waitFor(() => {
+      // Two tiles — one per card in the response
+      const buttons = screen.getAllByRole('button');
+      // Filter to tile buttons (aria-label contains card name)
+      const tiles = buttons.filter((b) =>
+        b.getAttribute('aria-label')?.includes('Lightning Bolt') ||
+        b.getAttribute('aria-label')?.includes('Sol Ring'),
+      );
+      expect(tiles).toHaveLength(2);
+    });
+  });
+
+  it('opens the popover for the clicked tile', async () => {
+    mockGetCardAllocations.mockResolvedValue(SAMPLE_RESPONSE);
+
+    renderWithQuery(<CardAllocations />);
+
+    // Wait for tiles to appear
+    const boltTile = await screen.findByRole('button', { name: /Lightning Bolt/i });
+    await userEvent.click(boltTile);
+
+    // Popover dialog should now be visible
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Available — not in any deck')).toBeInTheDocument();
+  });
+
+  it('shows an informative message for a 501 response (no Postgres)', async () => {
+    mockGetCardAllocations.mockRejectedValue(
+      new Error('Failed to fetch allocations: 501'),
+    );
+
+    renderWithQuery(<CardAllocations />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Deck features require a Postgres database/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls removeCardFromDeck and invalidates cache on remove', async () => {
+    mockGetCardAllocations.mockResolvedValue(SAMPLE_RESPONSE);
+    mockRemoveCardFromDeck.mockResolvedValue(undefined);
+
+    renderWithQuery(<CardAllocations />);
+
+    // Click the Sol Ring tile (which is in one deck)
+    const solRingTile = await screen.findByRole('button', { name: /Sol Ring/i });
+    await userEvent.click(solRingTile);
+
+    // Click the Remove button in the popover
+    const removeBtn = await screen.findByRole('button', { name: /remove from commander deck/i });
+    await userEvent.click(removeBtn);
+
+    await waitFor(() => {
+      expect(mockRemoveCardFromDeck).toHaveBeenCalledWith(10, 2);
+    });
+  });
+});

--- a/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/confidence-score.json
+++ b/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/confidence-score.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1",
+  "change": "cross-deck-card-allocation",
+  "agent": "reviewer",
+  "scored_at": "2026-03-16T08:00:00Z",
+  "overall": 86,
+  "aspects": {
+    "type_correctness": 92,
+    "pattern_adherence": 88,
+    "test_coverage": 90,
+    "security": 85,
+    "architectural_alignment": 87
+  },
+  "notes": {
+    "type_correctness": "AllocationTile, AllocationPopover, and CardAllocations all use correctly typed props and API types from client.ts. The CardAllocation type is imported as a type-only import where appropriate after fixes.",
+    "pattern_adherence": "i18n strings were missing on initial delivery — added allocations namespace to en.json/es.json and wired useTranslation() into all three components. Now matches project-wide i18n pattern. aria-modal was incorrectly set on a non-modal popover — removed.",
+    "test_coverage": "Unit tests cover getAllocationStatus, AllocationTile rendering (all three badge states), click handler, and CardAllocations page states (loading, data, error, remove). Coverage is thorough for the scope.",
+    "security": "No new attack surface. The IDOR gap noted by security reviewer is mitigated at the route handler level. Allocations query is user-scoped in the repository.",
+    "architectural_alignment": "API calls go through api/client.ts. Repository pattern is respected. CardAllocations page correctly delegates to service layer. AllocationPopover is a pure presentational component."
+  },
+  "flags": []
+}

--- a/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/context-bundle.md
+++ b/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/context-bundle.md
@@ -1,0 +1,620 @@
+# Context Bundle: Cross-Deck Card Allocation Visualization
+
+This file provides the exact file locations, relevant code sections, and precise changes
+needed for each implementation task. A developer should be able to implement the full feature
+using this file plus the design and tasks docs.
+
+---
+
+## Key Files
+
+### Backend
+
+| File | Role |
+|------|------|
+| `deckdex/storage/deck_repository.py` | Add `get_all_card_allocations` method |
+| `backend/api/routes/cards.py` | Add `GET /api/cards/allocations` route and Pydantic models |
+| `backend/api/dependencies.py` | `get_current_user_id`, `get_deck_repo` — no changes needed |
+| `tests/test_allocations.py` | New test file |
+
+### Frontend
+
+| File | Role |
+|------|------|
+| `frontend/src/api/client.ts` | Add types and `getCardAllocations` method |
+| `frontend/src/components/AllocationTile.tsx` | New component |
+| `frontend/src/components/AllocationPopover.tsx` | New component |
+| `frontend/src/pages/CardAllocations.tsx` | New page |
+| `frontend/src/components/Navbar.tsx` | Add nav link |
+| `frontend/src/App.tsx` | Register route |
+| `frontend/src/locales/en.json` | Add i18n key |
+| `frontend/src/locales/es.json` | Add i18n key |
+
+---
+
+## Backend Changes
+
+### `deckdex/storage/deck_repository.py`
+
+Add at end of class `DeckRepository`:
+
+```python
+def get_all_card_allocations(self, user_id: int) -> list[dict]:
+    """Return all cards for user with their deck assignments.
+
+    Returns a flat list of rows: one row per (card, deck) pair.
+    Cards in no deck appear once with deck_id=None, deck_name=None.
+    """
+    sql = """
+        SELECT
+            c.id        AS card_id,
+            c.name      AS card_name,
+            c.image_url,
+            c.type_line,
+            c.mana_cost,
+            c.quantity,
+            d.id        AS deck_id,
+            d.name      AS deck_name
+        FROM cards c
+        LEFT JOIN deck_cards dc ON dc.card_id = c.id
+        LEFT JOIN decks d       ON d.id = dc.deck_id AND d.user_id = %(user_id)s
+        WHERE c.user_id = %(user_id)s
+        ORDER BY c.name ASC
+    """
+    with self._get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, {"user_id": user_id})
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row)) for row in cur.fetchall()]
+```
+
+Note: Match the existing `_get_connection` / cursor pattern used elsewhere in the file.
+If the repo uses a different DB access pattern (e.g. `psycopg2` context manager, SQLAlchemy
+session), adapt accordingly while keeping the SQL query identical.
+
+---
+
+### `backend/api/routes/cards.py`
+
+**Step 1:** Add Pydantic models near the top of the file (after existing imports):
+
+```python
+class DeckRef(BaseModel):
+    deck_id: int
+    deck_name: str
+
+class CardAllocation(BaseModel):
+    card_id: int
+    card_name: str
+    image_url: Optional[str] = None
+    type_line: Optional[str] = None
+    mana_cost: Optional[str] = None
+    quantity: int
+    decks: List[DeckRef]
+
+class CardAllocationsResponse(BaseModel):
+    cards: List[CardAllocation]
+```
+
+**Step 2:** Add the route. It MUST be placed before any route that has a path parameter
+`/{id}` or `/{card_id}` in the same router to prevent "allocations" being matched as an id:
+
+```python
+@router.get("/allocations", response_model=CardAllocationsResponse)
+async def get_card_allocations(
+    repo: DeckRepository = Depends(require_deck_repo),
+    user_id: int = Depends(get_current_user_id),
+):
+    """Return all collection cards with their deck assignment lists."""
+    rows = repo.get_all_card_allocations(user_id=user_id)
+
+    # Aggregate flat rows into per-card structure
+    seen: dict[int, CardAllocation] = {}
+    for row in rows:
+        cid = row["card_id"]
+        if cid not in seen:
+            seen[cid] = CardAllocation(
+                card_id=cid,
+                card_name=row["card_name"] or "",
+                image_url=row.get("image_url"),
+                type_line=row.get("type_line"),
+                mana_cost=row.get("mana_cost"),
+                quantity=row.get("quantity") or 1,
+                decks=[],
+            )
+        if row.get("deck_id") is not None:
+            seen[cid].decks.append(
+                DeckRef(deck_id=row["deck_id"], deck_name=row["deck_name"])
+            )
+
+    return CardAllocationsResponse(cards=list(seen.values()))
+```
+
+**Step 3:** Check that `require_deck_repo` and `get_current_user_id` are already imported
+in `cards.py`. If `require_deck_repo` is currently only in `decks.py`, either:
+  (a) Move it to `backend/api/dependencies.py` and import from both route files, or
+  (b) Duplicate the guard in `cards.py` (less preferred — leads to drift).
+
+Option (a) is recommended. The existing `require_deck_repo` function in `decks.py`:
+```python
+def require_deck_repo() -> DeckRepository:
+    repo = get_deck_repo()
+    if repo is None:
+        raise HTTPException(
+            status_code=501,
+            detail="Decks require Postgres. Set DATABASE_URL to use the deck builder.",
+        )
+    return repo
+```
+Move this to `backend/api/dependencies.py` and update `decks.py` import.
+
+---
+
+### `tests/test_allocations.py` (new file)
+
+```python
+"""Tests for GET /api/cards/allocations endpoint."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api.main import app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture()
+def mock_user_id():
+    with patch("backend.api.dependencies.get_current_user_id", return_value=1):
+        yield 1
+
+
+@pytest.fixture()
+def mock_deck_repo():
+    repo = MagicMock()
+    with patch("backend.api.dependencies.get_deck_repo", return_value=repo):
+        yield repo
+
+
+def test_allocations_unauthenticated(client):
+    """Unauthenticated request returns 401."""
+    response = client.get("/api/cards/allocations")
+    assert response.status_code == 401
+
+
+def test_allocations_no_postgres(client, mock_user_id):
+    """Returns 501 when Postgres is not configured."""
+    with patch("backend.api.dependencies.get_deck_repo", return_value=None):
+        response = client.get("/api/cards/allocations")
+    assert response.status_code == 501
+
+
+def test_allocations_empty_collection(client, mock_user_id, mock_deck_repo):
+    """Returns empty cards list when user has no cards."""
+    mock_deck_repo.get_all_card_allocations.return_value = []
+    response = client.get("/api/cards/allocations")
+    assert response.status_code == 200
+    assert response.json() == {"cards": []}
+
+
+def test_allocations_card_in_no_deck(client, mock_user_id, mock_deck_repo):
+    """Card with deck_id=None appears with empty decks array."""
+    mock_deck_repo.get_all_card_allocations.return_value = [
+        {"card_id": 1, "card_name": "Lightning Bolt", "image_url": None,
+         "type_line": "Instant", "mana_cost": "{R}", "quantity": 1,
+         "deck_id": None, "deck_name": None},
+    ]
+    response = client.get("/api/cards/allocations")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["cards"]) == 1
+    assert data["cards"][0]["decks"] == []
+
+
+def test_allocations_card_in_one_deck(client, mock_user_id, mock_deck_repo):
+    """Card in one deck has one entry in decks array."""
+    mock_deck_repo.get_all_card_allocations.return_value = [
+        {"card_id": 2, "card_name": "Sol Ring", "image_url": None,
+         "type_line": "Artifact", "mana_cost": "{1}", "quantity": 1,
+         "deck_id": 10, "deck_name": "My Commander"},
+    ]
+    response = client.get("/api/cards/allocations")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["cards"]) == 1
+    assert len(data["cards"][0]["decks"]) == 1
+    assert data["cards"][0]["decks"][0]["deck_id"] == 10
+
+
+def test_allocations_card_in_multiple_decks(client, mock_user_id, mock_deck_repo):
+    """Card in two decks appears once with two entries in decks array."""
+    mock_deck_repo.get_all_card_allocations.return_value = [
+        {"card_id": 3, "card_name": "Island", "image_url": None,
+         "type_line": "Land", "mana_cost": None, "quantity": 4,
+         "deck_id": 10, "deck_name": "Deck A"},
+        {"card_id": 3, "card_name": "Island", "image_url": None,
+         "type_line": "Land", "mana_cost": None, "quantity": 4,
+         "deck_id": 11, "deck_name": "Deck B"},
+    ]
+    response = client.get("/api/cards/allocations")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["cards"]) == 1  # deduplicated
+    assert len(data["cards"][0]["decks"]) == 2
+```
+
+Note: Adjust the mock/patch paths to match actual import paths in your project structure.
+If `get_current_user_id` is applied via a cookie dependency (not patchable directly),
+use `app.dependency_overrides` pattern instead.
+
+---
+
+## Frontend Changes
+
+### `frontend/src/api/client.ts`
+
+Add after the `BatchAddResult` interface (around line 187):
+
+```typescript
+export interface DeckRef {
+  deck_id: number;
+  deck_name: string;
+}
+
+export interface CardAllocation {
+  card_id: number;
+  card_name: string;
+  image_url: string | null;
+  type_line: string | null;
+  mana_cost: string | null;
+  quantity: number;
+  decks: DeckRef[];
+}
+
+export interface CardAllocationsResponse {
+  cards: CardAllocation[];
+}
+```
+
+Add to the `api` object (find the closing `}` of the `api` const and add before it):
+
+```typescript
+  getCardAllocations: async (): Promise<CardAllocationsResponse> => {
+    const res = await apiFetch(`${API_BASE}/cards/allocations`);
+    if (!res.ok) throw new Error(`Failed to fetch allocations: ${res.status}`);
+    return res.json();
+  },
+```
+
+---
+
+### `frontend/src/components/Navbar.tsx`
+
+In the `navLinks` array (around line 56), add between the decks and analytics entries:
+
+```typescript
+{ path: '/allocations', label: t('navbar.allocations'), badge: 'alpha' },
+```
+
+Result:
+```typescript
+const navLinks = [
+  { path: '/dashboard', label: t('navbar.collection') },
+  { path: '/decks', label: t('navbar.deckBuilder'), badge: 'alpha' },
+  { path: '/allocations', label: t('navbar.allocations'), badge: 'alpha' },
+  { path: '/analytics', label: t('navbar.analytics'), badge: 'beta' },
+  ...(user?.is_admin ? [{ path: '/admin', label: t('navbar.admin') }] : []),
+];
+```
+
+---
+
+### `frontend/src/locales/en.json`
+
+Add to the `navbar` section:
+```json
+"allocations": "Allocations"
+```
+
+### `frontend/src/locales/es.json`
+
+Add to the `navbar` section:
+```json
+"allocations": "Asignaciones"
+```
+
+---
+
+### `frontend/src/App.tsx`
+
+Add import:
+```typescript
+import { CardAllocations } from './pages/CardAllocations';
+```
+
+Add route inside the authenticated route tree (alongside `/decks`):
+```tsx
+<Route path="/allocations" element={<ProtectedRoute><CardAllocations /></ProtectedRoute>} />
+```
+
+---
+
+## Component Skeletons
+
+### `frontend/src/components/AllocationTile.tsx`
+
+```tsx
+import { useRef, useEffect, useState } from 'react';
+import type { CardAllocation } from '../api/client';
+import { useImageCache } from '../hooks/useImageCache';
+
+export type AllocationStatus = 'available' | 'assigned' | 'shared';
+
+export function getAllocationStatus(deckCount: number): AllocationStatus {
+  if (deckCount === 0) return 'available';
+  if (deckCount === 1) return 'assigned';
+  return 'shared';
+}
+
+const STATUS_COLORS: Record<AllocationStatus, string> = {
+  available: 'bg-green-500',
+  assigned: 'bg-orange-500',
+  shared: 'bg-red-500',
+};
+
+const STATUS_LABELS: Record<AllocationStatus, string> = {
+  available: 'Available',
+  assigned: 'In 1 deck',
+  shared: 'In multiple decks',
+};
+
+interface AllocationTileProps {
+  allocation: CardAllocation;
+  onTileClick: (allocation: CardAllocation) => void;
+}
+
+export function AllocationTile({ allocation, onTileClick }: AllocationTileProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLButtonElement>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    observerRef.current = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observerRef.current?.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observerRef.current.observe(el);
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  const cardId = isVisible ? allocation.card_id : null;
+  const { src } = useImageCache(cardId);
+  const status = getAllocationStatus(allocation.decks.length);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      onClick={() => onTileClick(allocation)}
+      aria-label={`${allocation.card_name} — ${STATUS_LABELS[status]}`}
+      className="relative aspect-[63/88] rounded-lg overflow-hidden bg-gray-200 dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 w-full"
+    >
+      {src && (
+        <img
+          src={src}
+          alt={allocation.card_name}
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+      )}
+      {/* Status badge */}
+      <span
+        aria-hidden="true"
+        className={`absolute bottom-1 right-1 w-3 h-3 rounded-full border-2 border-white dark:border-gray-800 ${STATUS_COLORS[status]}`}
+      />
+    </button>
+  );
+}
+```
+
+---
+
+### `frontend/src/components/AllocationPopover.tsx`
+
+```tsx
+import { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+import type { CardAllocation } from '../api/client';
+
+interface AllocationPopoverProps {
+  allocation: CardAllocation;
+  onRemoveFromDeck: (deckId: number, cardId: number) => void;
+  onClose: () => void;
+}
+
+export function AllocationPopover({ allocation, onRemoveFromDeck, onClose }: AllocationPopoverProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${allocation.card_name} allocation details`}
+      className="absolute z-50 top-0 left-full ml-2 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-600 p-3"
+    >
+      <div className="flex items-start justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white pr-2 leading-tight">
+          {allocation.card_name}
+        </h3>
+        <button
+          ref={closeRef}
+          onClick={onClose}
+          aria-label="Close"
+          className="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {allocation.decks.length === 0 ? (
+        <p className="text-xs text-green-600 dark:text-green-400">
+          Available — not in any deck
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {allocation.decks.map((deck) => (
+            <li key={deck.deck_id} className="flex items-center justify-between gap-2">
+              <span className="text-xs text-gray-700 dark:text-gray-300 truncate">
+                {deck.deck_name}
+              </span>
+              <button
+                onClick={() => onRemoveFromDeck(deck.deck_id, allocation.card_id)}
+                aria-label={`Remove from ${deck.deck_name}`}
+                className="flex-shrink-0 text-xs text-red-600 dark:text-red-400 hover:underline focus:outline-none focus:ring-2 focus:ring-red-500 rounded"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+```
+
+---
+
+### `frontend/src/pages/CardAllocations.tsx`
+
+```tsx
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api/client';
+import type { CardAllocation } from '../api/client';
+import { AllocationTile } from '../components/AllocationTile';
+import { AllocationPopover } from '../components/AllocationPopover';
+
+export function CardAllocations() {
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<CardAllocation | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['card-allocations'],
+    queryFn: api.getCardAllocations,
+  });
+
+  const handleRemove = async (deckId: number, cardId: number) => {
+    await api.removeDeckCard(deckId, cardId);
+    await queryClient.invalidateQueries({ queryKey: ['card-allocations'] });
+    setSelected(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  // Detect 501 (no Postgres) — the thrown error includes the status code
+  if (error) {
+    const msg = error instanceof Error ? error.message : '';
+    const isNoPg = msg.includes('501');
+    return (
+      <div className="p-6 text-center text-gray-500 dark:text-gray-400">
+        {isNoPg
+          ? 'Deck features require a Postgres database. Set DATABASE_URL to enable allocations.'
+          : 'Failed to load allocations. Please try again.'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Card Allocations</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          See where each card is used across your decks.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+        {data?.cards.map((allocation) => (
+          <div key={allocation.card_id} className="relative">
+            <AllocationTile
+              allocation={allocation}
+              onTileClick={setSelected}
+            />
+            {selected?.card_id === allocation.card_id && (
+              <AllocationPopover
+                allocation={allocation}
+                onRemoveFromDeck={handleRemove}
+                onClose={() => setSelected(null)}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## Existing Code Reuse
+
+| Component/Hook | Where reused in this feature |
+|----------------|------------------------------|
+| `useImageCache(cardId)` | `AllocationTile` — same lazy image loading as `CardGallery` |
+| `api.removeDeckCard(deckId, cardId)` | `CardAllocations` page remove handler — already in `client.ts` |
+| `apiFetch` | New `getCardAllocations` method in `client.ts` |
+| `ProtectedRoute` | Wrapping `/allocations` in `App.tsx` |
+| `DeckRepository.require_deck_repo` guard | Reused (moved to `dependencies.py`) for allocations route |
+| TanStack Query `useQuery` + `invalidateQueries` | Same pattern as DeckBuilder and Dashboard pages |
+
+---
+
+## Warnings
+
+- **FastAPI route order:** `GET /api/cards/allocations` must be registered before
+  `GET /api/cards/{id}` or any other parameterized card route. Failure to do so will cause
+  `"allocations"` to be parsed as a card id (integer coercion will fail with a 422, but the
+  wrong handler will be invoked). Confirm by checking that `router.get("/allocations")` is
+  defined before `router.get("/{id}")` in `cards.py`.
+
+- **`require_deck_repo` location:** If this guard is only in `decks.py`, it must be moved
+  to `dependencies.py` before both route files can import it. This is a safe refactor with
+  no behavior change.
+
+- **Popover z-index:** The popover uses `absolute` positioning. If the grid tiles are
+  inside a container with `overflow: hidden`, the popover will be clipped. Set
+  `overflow: visible` on the containing element or use a portal (e.g., React `createPortal`
+  into `document.body`). The current skeleton uses `left-full ml-2` which positions the
+  popover to the right of the tile — ensure tiles near the right edge don't get clipped by
+  the page container. An edge-case fix can be deferred to a follow-up.
+
+- **`api.removeDeckCard` method name:** Confirm the exact method name in `client.ts`.
+  It may be `deleteCardFromDeck`, `removeDeckCard`, or similar. Check the existing
+  `DeckDetailModal.tsx` for the correct call pattern and use the same method name.

--- a/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/delta-spec.md
+++ b/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/delta-spec.md
@@ -1,0 +1,106 @@
+# Delta Spec: Cross-Deck Card Allocation Visualization
+
+This file documents the additions and changes to existing specs triggered by this feature.
+
+---
+
+## Changes to `openspec/specs/decks/spec.md`
+
+### ADD: Requirement — Card allocation query
+
+```
+### Requirement: Card allocation query across all decks
+
+The system SHALL expose a method in DeckRepository (or equivalent data layer) to retrieve
+all cards owned by a user alongside the decks they are assigned to. The method SHALL return
+a result that allows the caller to determine, for each card: the card's id, name, and
+metadata; and the list of deck ids and names that include that card.
+
+#### Scenario: Query with mixed allocation state
+- **WHEN** the user has cards in no decks, cards in one deck, and cards in multiple decks
+- **THEN** the query result SHALL correctly associate each card with zero, one, or many deck entries
+
+#### Scenario: Query when no decks exist
+- **WHEN** the user has cards but no decks
+- **THEN** all cards SHALL be returned with an empty deck list
+```
+
+---
+
+## Changes to `openspec/specs/web-api-backend/spec.md`
+
+### ADD: Requirement — GET /api/cards/allocations endpoint
+
+```
+### Requirement: Card allocations endpoint
+
+The system SHALL expose GET /api/cards/allocations. The endpoint SHALL require authentication
+(get_current_user). It SHALL return all cards belonging to the authenticated user, each with
+the list of decks the card is assigned to (may be empty). The response SHALL include for each
+card: card_id, card_name, image_url, type_line, mana_cost, quantity, and a decks array
+(each entry: deck_id, deck_name). When Postgres is not configured, the endpoint SHALL return
+HTTP 501. The route SHALL be registered before any wildcard card routes to avoid path conflicts.
+
+#### Scenario: Authenticated user with cards and decks
+- **WHEN** the user calls GET /api/cards/allocations with a valid session
+- **THEN** the response contains all the user's cards; cards assigned to decks include those
+  deck references; cards in no deck have an empty decks array
+
+#### Scenario: Unauthenticated request
+- **WHEN** the request has no valid JWT cookie
+- **THEN** the endpoint returns HTTP 401
+
+#### Scenario: No Postgres configured
+- **WHEN** DATABASE_URL is not set and the user calls GET /api/cards/allocations
+- **THEN** the endpoint returns HTTP 501 with a descriptive message
+```
+
+---
+
+## Changes to `openspec/specs/deck-builder-ui/spec.md`
+
+### ADD: Requirement — Allocation visualization page
+
+```
+### Requirement: Cross-deck card allocation page
+
+The system SHALL provide a page at route /allocations accessible from the main navigation
+(labeled e.g. "Allocations" with an "alpha" badge). The page SHALL display all cards in the
+user's collection as an image grid. Each card tile SHALL show a color-coded status indicator:
+green when the card is in no deck (available), orange when the card is in exactly one deck,
+red when the card is in two or more decks. Clicking a card tile SHALL open a detail popover
+showing the card's name and the list of decks it is assigned to. When a card is in one or
+more decks, each deck entry SHALL have a "Remove" action that removes the card from that deck
+and updates the tile status. The page SHALL require authentication. When Postgres is not
+available, the page SHALL display an informative message rather than an error.
+
+#### Scenario: Grid displays status badges
+- **WHEN** the user navigates to /allocations
+- **THEN** each card tile shows a status badge: green (not in any deck), orange (in 1 deck),
+  red (in 2+ decks)
+
+#### Scenario: Popover shows deck assignments
+- **WHEN** the user clicks a card tile
+- **THEN** a popover opens listing the card's name and each deck it belongs to (or a message
+  indicating it is available if in no deck)
+
+#### Scenario: Remove card from deck via popover
+- **WHEN** the user clicks "Remove" next to a deck in the card allocation popover
+- **THEN** the system calls DELETE /api/decks/{deck_id}/cards/{card_id}, the popover updates
+  to reflect the removal, and the tile's status badge updates accordingly
+
+#### Scenario: No Postgres
+- **WHEN** the backend returns 501 for the allocations request
+- **THEN** the page displays a message explaining that deck features require Postgres
+  (DATABASE_URL must be configured)
+```
+
+---
+
+## No Changes Required
+
+The following specs are unaffected by this feature:
+
+- `openspec/specs/data-model/spec.md` — no schema changes; all data is derivable from existing tables.
+- `openspec/specs/decks/spec.md` — existing CRUD endpoints are unchanged; only an additive query method is added.
+- All other specs (analytics, settings, CLI, etc.) — fully orthogonal.

--- a/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/design.md
+++ b/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/design.md
@@ -1,0 +1,272 @@
+# Technical Design: Cross-Deck Card Allocation Visualization
+
+## Context
+
+The existing stack:
+- `deck_cards` table: (deck_id, card_id, quantity, is_commander). PK is (deck_id, card_id).
+- `decks` table: id, name, user_id.
+- `cards` table: id, name, image_url, type_line, mana_cost, prices, user_id.
+- `DeckRepository` in `deckdex/storage/deck_repository.py` handles all deck/card DB queries.
+- The frontend has a working `CardGallery` component with lazy-loaded image tiles, `useImageCache` hook, and the `apiFetch` client in `api/client.ts`.
+- The `/decks` route uses `DeckDetailModal` + `DeckCardPickerModal`; card removal calls `DELETE /api/decks/{deck_id}/cards/{card_id}`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose all card allocation data in a single API call (cards + their deck memberships), scoped to the authenticated user.
+- Render a full image grid at `/allocations` with color-coded status overlays.
+- Allow removing a card from a specific deck directly from a click-through popover.
+
+**Non-Goals:**
+- Adding cards to decks from this view.
+- Deck filtering (show cards only in a specific deck) — future iteration.
+- Paginating the allocations endpoint (client receives all at once; the collection is user-scoped and manageable in a single query with a JOIN).
+
+---
+
+## 1. Backend
+
+### 1.1 New Endpoint: `GET /api/cards/allocations`
+
+**Route file:** `backend/api/routes/cards.py` (add new route) OR a new `backend/api/routes/allocations.py` included in `backend/api/main.py`.
+
+Recommended: add to `cards.py` to avoid proliferating route files for a single endpoint. The route path `GET /api/cards/allocations` must be registered **before** any generic `GET /api/cards/{id}` wildcard route to avoid path collision in FastAPI. FastAPI evaluates routes in registration order for same-prefix conflicts.
+
+**Authentication:** `get_current_user_id` dependency, same as all data endpoints.
+
+**DB query:** Single query with a LEFT JOIN:
+
+```sql
+SELECT
+    c.id            AS card_id,
+    c.name          AS card_name,
+    c.image_url,
+    c.type_line,
+    c.mana_cost,
+    c.quantity,
+    d.id            AS deck_id,
+    d.name          AS deck_name
+FROM cards c
+LEFT JOIN deck_cards dc ON dc.card_id = c.id
+LEFT JOIN decks d       ON d.id = dc.deck_id AND d.user_id = %(user_id)s
+WHERE c.user_id = %(user_id)s
+ORDER BY c.name ASC
+```
+
+This returns one row per (card, deck) pair. Cards in no deck appear once with `deck_id = NULL`. The aggregation into the response shape is done in Python (not SQL) for simplicity and to avoid a JSONB aggregation dependency.
+
+**Response shape (Pydantic model):**
+
+```python
+class DeckRef(BaseModel):
+    deck_id: int
+    deck_name: str
+
+class CardAllocation(BaseModel):
+    card_id: int
+    card_name: str
+    image_url: str | None
+    type_line: str | None
+    mana_cost: str | None
+    quantity: int
+    decks: list[DeckRef]   # empty list = card is available (in no deck)
+
+class CardAllocationsResponse(BaseModel):
+    cards: list[CardAllocation]
+```
+
+`decks` being an empty list means "available" — this is the canonical definition of the green state. The frontend derives status from `len(decks)`.
+
+**501 when no Postgres:** Same guard as deck routes — if `DeckRepository` is unavailable (no `DATABASE_URL`), return 501 with a clear message.
+
+**Implementation note:** The aggregation loop in Python:
+```python
+seen: dict[int, CardAllocation] = {}
+for row in rows:
+    if row["card_id"] not in seen:
+        seen[row["card_id"]] = CardAllocation(
+            card_id=row["card_id"],
+            card_name=row["card_name"],
+            image_url=row["image_url"],
+            type_line=row["type_line"],
+            mana_cost=row["mana_cost"],
+            quantity=row["quantity"],
+            decks=[],
+        )
+    if row["deck_id"] is not None:
+        seen[row["card_id"]].decks.append(
+            DeckRef(deck_id=row["deck_id"], deck_name=row["deck_name"])
+        )
+return CardAllocationsResponse(cards=list(seen.values()))
+```
+
+### 1.2 Where the Query Lives
+
+Add a method `get_all_card_allocations(user_id: int) -> list[dict]` to `DeckRepository`. This keeps all deck-related SQL in the repository layer, consistent with project conventions. The route handler calls this method and does the Python aggregation.
+
+Alternatively, add a new method to the card repository. However, the allocation JOIN spans both cards and deck_cards, which are already within `DeckRepository`'s scope. Keeping it there avoids cross-repository dependencies.
+
+---
+
+## 2. Frontend
+
+### 2.1 New API Client Method
+
+In `frontend/src/api/client.ts`, add:
+
+```typescript
+export interface DeckRef {
+  deck_id: number;
+  deck_name: string;
+}
+
+export interface CardAllocation {
+  card_id: number;
+  card_name: string;
+  image_url: string | null;
+  type_line: string | null;
+  mana_cost: string | null;
+  quantity: number;
+  decks: DeckRef[];
+}
+
+export interface CardAllocationsResponse {
+  cards: CardAllocation[];
+}
+```
+
+And in the `api` object:
+```typescript
+getCardAllocations: async (): Promise<CardAllocationsResponse> => {
+  const res = await apiFetch(`${API_BASE}/cards/allocations`);
+  if (!res.ok) throw new Error(`Failed to fetch allocations: ${res.status}`);
+  return res.json();
+},
+```
+
+### 2.2 New Page: `CardAllocations`
+
+**File:** `frontend/src/pages/CardAllocations.tsx`
+
+**Route:** `/allocations` — added to `App.tsx` under `ProtectedRoute`, alongside `/decks` and `/analytics`.
+
+**Data fetching:** Use `useQuery` from TanStack Query with key `['card-allocations']`. Show a spinner while loading. Show an error message on failure (including when the backend returns 501 for no Postgres — surface this as "deck features require Postgres").
+
+**Layout:** Reuse the same responsive grid as `CardGallery` (`grid-cols-[repeat(auto-fill,minmax(120px,1fr))]` or similar). Each tile is an `AllocationTile` component.
+
+### 2.3 `AllocationTile` Component
+
+**File:** `frontend/src/components/AllocationTile.tsx`
+
+Props:
+```typescript
+interface AllocationTileProps {
+  allocation: CardAllocation;
+  onRemoveFromDeck: (deckId: number, cardId: number) => void;
+}
+```
+
+**Rendering:**
+- Card image loaded via `useImageCache(allocation.card_id)` — reuses the existing lazy-load/cache hook.
+- Status badge: positioned bottom-right, small colored circle or pill.
+  - `decks.length === 0` → green (`bg-green-500`)
+  - `decks.length === 1` → orange (`bg-orange-500`)
+  - `decks.length >= 2` → red (`bg-red-500`)
+- Clicking the tile opens the `AllocationPopover` inline (toggle state local to tile).
+
+**Status derivation function** (pure, exported for tests):
+```typescript
+export type AllocationStatus = 'available' | 'assigned' | 'shared';
+
+export function getAllocationStatus(deckCount: number): AllocationStatus {
+  if (deckCount === 0) return 'available';
+  if (deckCount === 1) return 'assigned';
+  return 'shared';
+}
+```
+
+### 2.4 `AllocationPopover` Component
+
+**File:** `frontend/src/components/AllocationPopover.tsx`
+
+A small overlay anchored to the tile (positioned absolute within the tile's relative container, or rendered in a portal if overflow clipping is an issue). Opens on tile click, dismisses on outside click or Escape.
+
+**Content when `decks.length === 0`:**
+```
+Card name
+"Available — not in any deck"
+[Close]
+```
+
+**Content when `decks.length >= 1`:**
+```
+Card name
+Assigned to:
+  [Deck A name]  [Remove]
+  [Deck B name]  [Remove]
+[Close]
+```
+
+The `[Remove]` button calls `onRemoveFromDeck(deckId, cardId)` passed down from `CardAllocations` page. The page handler calls `api.removeDeckCard(deckId, cardId)` then invalidates the `['card-allocations']` query via `queryClient.invalidateQueries`.
+
+**Accessibility:**
+- `role="dialog"`, `aria-label="Card allocation details"`.
+- Focus trap within the popover while open.
+- Escape key closes it.
+
+### 2.5 Nav Link
+
+In `Navbar.tsx`, add an entry to `navLinks`:
+```typescript
+{ path: '/allocations', label: t('navbar.allocations'), badge: 'alpha' },
+```
+
+Add the i18n key `navbar.allocations` to `en.json` and `es.json`.
+
+### 2.6 Router Registration
+
+In `App.tsx` (or wherever routes are defined), add:
+```tsx
+<Route path="/allocations" element={<ProtectedRoute><CardAllocations /></ProtectedRoute>} />
+```
+
+---
+
+## 3. Key Design Decisions
+
+### Decision 1: Single JOIN query vs. multiple requests
+A single SQL JOIN returning all allocation data in one round-trip is the correct approach here. The alternative (fetch all cards, then fetch all deck memberships separately, merge in the frontend) would require two API calls and client-side join logic. The JOIN in the repository layer is cleaner, tested in one place, and requires zero extra latency.
+
+### Decision 2: Aggregation in Python vs. SQL JSONB
+SQL `json_agg` / `array_agg` would let us return the grouped result directly. However, this introduces a PostgreSQL-specific function and is harder to mock in tests. Python-side aggregation over a flat row list is portable, readable, and consistent with how the rest of the project handles multi-row results from the repository layer.
+
+### Decision 3: Popover vs. modal for card detail
+A popover (anchored to the tile) is more appropriate than a full-screen modal here because the action (remove from deck) is lightweight. The existing `CardDetailModal` is heavyweight by design. Opening it on every tile click in a grid of 1,000 cards would be disorienting. The popover keeps focus local to the card and dismisses trivially.
+
+### Decision 4: Route placement in `cards.py`
+Adding `/api/cards/allocations` to the existing `cards.py` router keeps the router file count low. The critical constraint is FastAPI route registration order: the `allocations` literal path must appear before any `/{id}` wildcard in the same router. Since FastAPI uses the first matching route for a given request, registering `GET /allocations` before `GET /{id}` prevents `"allocations"` from being matched as a card id.
+
+### Decision 5: No Postgres → 501, consistent with deck routes
+Allocation data depends on `deck_cards`, which only exists in Postgres. Returning 501 mirrors the existing pattern in `decks.py` (`require_deck_repo()`). The frontend should detect this and show an informative message rather than an error toast.
+
+---
+
+## 4. Data Flow Summary
+
+```
+User navigates to /allocations
+  → CardAllocations page mounts
+  → useQuery(['card-allocations']) fires
+  → GET /api/cards/allocations
+  → FastAPI authenticates (JWT cookie)
+  → DeckRepository.get_all_card_allocations(user_id)
+  → SQL LEFT JOIN: cards + deck_cards + decks
+  → Python aggregation → CardAllocationsResponse
+  → JSON response
+  → AllocationTile rendered per card, status badge derived from decks.length
+  → User clicks tile → AllocationPopover opens
+  → User clicks [Remove] on a deck
+  → DELETE /api/decks/{deck_id}/cards/{card_id}
+  → queryClient.invalidateQueries(['card-allocations'])
+  → Grid re-renders with updated badge
+```

--- a/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/proposal.md
+++ b/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: Cross-Deck Card Allocation Visualization
+
+## Problem Statement
+
+MTG players who maintain multiple Commander decks face a recurring problem: they cannot tell at a glance whether a card in their collection is "committed" to one or more decks, or still available. Today, checking a card's availability requires opening each deck's detail modal individually and scanning the list. For a collector with 10+ decks and a shared pool of 1,000+ cards, this is impractical.
+
+The result: players accidentally build decks around cards already in another deck, or fail to leverage high-value cards sitting unused across the collection.
+
+## Value
+
+This feature delivers a single-screen answer to "where are my cards?" It allows the user to:
+
+- Immediately see which cards are free, committed to one deck, or shared across multiple decks.
+- Click any card to learn exactly which decks it belongs to and reallocate in two clicks.
+- Make smarter deck-building decisions without context-switching between the deck builder and the collection view.
+
+This is a read-heavy, display-heavy feature with lightweight write actions (remove card from deck). No new data needs to be stored — the allocation state is fully derivable from existing `deck_cards` rows.
+
+## Scope
+
+**In scope:**
+- New backend endpoint `GET /api/cards/allocations` returning each card's deck assignments for the current user.
+- New frontend page at route `/allocations` with a full card image grid.
+- Color-coded status badges on each card tile: green (available / in no deck), orange (in exactly 1 deck), red (in 2+ decks).
+- Card detail popover on tile click: shows which deck(s) the card belongs to and a remove-from-deck action per deck.
+- Nav link to the new page in the header.
+- Backend tests for the new endpoint.
+- Frontend tests for the new page and popover.
+
+**Out of scope:**
+- Adding cards to decks from this page (use DeckBuilder for that).
+- Filtering/sorting the allocation grid beyond the existing collection filters (future iteration).
+- Google Sheets support (allocations require Postgres, consistent with all deck features).
+- Real-time WebSocket updates (full page refetch after reallocation is acceptable).
+
+## Relationship to Existing Features
+
+The allocation page is a read-only complement to the DeckBuilder (`/decks`). It does not replace any existing screen. It reuses `CardGallery` (or its internals) for the grid, the existing `DeckRepository` for data, and the deck remove-card API that already exists.
+
+## Success Criteria
+
+1. The allocation page loads and renders all collection cards with correct color-coded badges.
+2. Clicking a card opens a popover listing assigned decks (0, 1, or many).
+3. Removing a card from a deck from the popover calls `DELETE /api/decks/{id}/cards/{card_id}` and the badge updates without a full page reload.
+4. Cards in no deck show green; cards in exactly 1 deck show orange; cards in 2+ decks show red.
+5. The page is gated by authentication (same as all other data pages).

--- a/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/tasks.md
+++ b/openspec/changes/archive/2026-03-16-cross-deck-card-allocation/tasks.md
@@ -1,0 +1,418 @@
+# Implementation Tasks: Cross-Deck Card Allocation Visualization
+
+Tasks are ordered by dependency. Backend tasks must complete before frontend integration tasks.
+All tasks are atomic: each has a single clear deliverable and acceptance criteria.
+
+---
+
+## Phase 1 — Backend
+
+### Task B1: Add `get_all_card_allocations` to DeckRepository [backend]
+
+**File:** `deckdex/storage/deck_repository.py`
+
+**Description:**
+Add method `get_all_card_allocations(self, user_id: int) -> list[dict]` to `DeckRepository`.
+The method executes a LEFT JOIN query:
+
+```sql
+SELECT
+    c.id        AS card_id,
+    c.name      AS card_name,
+    c.image_url,
+    c.type_line,
+    c.mana_cost,
+    c.quantity,
+    d.id        AS deck_id,
+    d.name      AS deck_name
+FROM cards c
+LEFT JOIN deck_cards dc ON dc.card_id = c.id
+LEFT JOIN decks d       ON d.id = dc.deck_id AND d.user_id = %(user_id)s
+WHERE c.user_id = %(user_id)s
+ORDER BY c.name ASC
+```
+
+Returns a list of raw dicts (one row per card-deck pair; cards in no deck appear once with
+`deck_id = None`).
+
+**Acceptance criteria:**
+- Method exists on `DeckRepository` and executes without error against a real DB.
+- Returns an empty list when the user has no cards.
+- Returns one row per card when the user has cards but no decks (deck_id=None in each row).
+- Returns multiple rows for the same card when it is in multiple decks.
+- Rows are ordered by card name ascending.
+
+**Dependencies:** None (pure DB layer addition).
+
+---
+
+### Task B2: Add Pydantic response models for allocations [backend]
+
+**File:** `backend/api/routes/cards.py` (or a new `backend/api/routes/allocations.py`)
+
+**Description:**
+Define Pydantic models:
+```python
+class DeckRef(BaseModel):
+    deck_id: int
+    deck_name: str
+
+class CardAllocation(BaseModel):
+    card_id: int
+    card_name: str
+    image_url: str | None = None
+    type_line: str | None = None
+    mana_cost: str | None = None
+    quantity: int
+    decks: list[DeckRef]
+
+class CardAllocationsResponse(BaseModel):
+    cards: list[CardAllocation]
+```
+
+**Acceptance criteria:**
+- Models are importable and Pydantic validates them correctly.
+- `CardAllocation` with `decks=[]` is valid (available card).
+- No existing model is modified.
+
+**Dependencies:** None.
+
+---
+
+### Task B3: Implement `GET /api/cards/allocations` route [backend]
+
+**File:** `backend/api/routes/cards.py`
+
+**Description:**
+Add route `GET /api/cards/allocations` using `get_current_user_id` and `require_deck_repo`
+(or equivalent guard for 501 when no Postgres). The handler:
+1. Calls `repo.get_all_card_allocations(user_id)` to get flat rows.
+2. Aggregates in Python: groups rows by `card_id`, builds `CardAllocation` with `decks` list.
+3. Returns `CardAllocationsResponse`.
+
+**Critical:** Register this route **before** any `GET /{id}` wildcard in the same router.
+In FastAPI, route matching is first-registration-wins for ambiguous paths.
+
+**Acceptance criteria:**
+- `GET /api/cards/allocations` returns HTTP 200 with `CardAllocationsResponse` shape when authenticated and Postgres is available.
+- Returns HTTP 401 when no valid JWT cookie is present.
+- Returns HTTP 501 when Postgres is not configured.
+- Path `/api/cards/allocations` is not accidentally matched as a card-by-id route.
+- Verify with `curl` or a test that the route resolves correctly even though `"allocations"` could look like a card id string.
+
+**Dependencies:** B1, B2.
+
+---
+
+### Task B4: Backend tests for the allocations endpoint [backend]
+
+**File:** `tests/test_allocations.py` (new file)
+
+**Description:**
+Write pytest tests using `scope="function"` fixtures with a mocked `DeckRepository`.
+Cover:
+1. Returns 401 when unauthenticated.
+2. Returns 501 when `get_deck_repo()` returns `None`.
+3. Happy path: mocked repo returns flat rows → response has correctly aggregated `cards` with `decks` populated.
+4. Card in no deck: `decks` array is empty in response.
+5. Card in multiple decks: `decks` array has multiple entries.
+6. Empty collection: `cards` array is empty.
+
+**All fixtures MUST use `scope="function"`** — module-scope mocks cause cross-test pollution
+(project-wide rule).
+
+Pydantic validation errors return HTTP 400, not 422 (project-wide convention). If any
+invalid payload test is added, assert 400.
+
+**Acceptance criteria:**
+- All 6+ test cases pass with `pytest tests/test_allocations.py`.
+- No `scope="module"` in fixture definitions.
+- Tests do not hit a real database.
+
+**Dependencies:** B3.
+
+---
+
+## Phase 2 — Frontend Types and API Client
+
+### Task F1: Add TypeScript types and API client method [frontend]
+
+**File:** `frontend/src/api/client.ts`
+
+**Description:**
+Add interfaces:
+```typescript
+export interface DeckRef {
+  deck_id: number;
+  deck_name: string;
+}
+
+export interface CardAllocation {
+  card_id: number;
+  card_name: string;
+  image_url: string | null;
+  type_line: string | null;
+  mana_cost: string | null;
+  quantity: number;
+  decks: DeckRef[];
+}
+
+export interface CardAllocationsResponse {
+  cards: CardAllocation[];
+}
+```
+
+Add method to the `api` export object:
+```typescript
+getCardAllocations: async (): Promise<CardAllocationsResponse> => {
+  const res = await apiFetch(`${API_BASE}/cards/allocations`);
+  if (!res.ok) throw new Error(`Failed to fetch allocations: ${res.status}`);
+  return res.json();
+},
+```
+
+**Acceptance criteria:**
+- TypeScript compiler accepts the new types with strict mode.
+- No existing interface is modified.
+- `api.getCardAllocations()` is callable from components.
+- Method uses `apiFetch` (not raw `fetch`), consistent with all other API calls.
+
+**Dependencies:** B3 (integration), but can be written before B3 is deployed.
+
+---
+
+## Phase 3 — Frontend Components
+
+### Task F2: Implement `getAllocationStatus` utility and `AllocationTile` component [frontend]
+
+**File:** `frontend/src/components/AllocationTile.tsx` (new file)
+
+**Description:**
+Create a pure utility function and tile component:
+
+```typescript
+export type AllocationStatus = 'available' | 'assigned' | 'shared';
+
+export function getAllocationStatus(deckCount: number): AllocationStatus {
+  if (deckCount === 0) return 'available';
+  if (deckCount === 1) return 'assigned';
+  return 'shared';
+}
+```
+
+`AllocationTile` renders:
+- Card image loaded via `useImageCache(allocation.card_id)` with lazy-load (IntersectionObserver pattern from `CardGallery`).
+- Status badge overlay (bottom-right corner, small pill):
+  - `available` → `bg-green-500`
+  - `assigned` → `bg-orange-500`
+  - `shared` → `bg-red-500`
+- Clicking tile calls `onTileClick(allocation)` prop.
+
+**Props interface:**
+```typescript
+interface AllocationTileProps {
+  allocation: CardAllocation;
+  onTileClick: (allocation: CardAllocation) => void;
+}
+```
+
+**Acceptance criteria:**
+- Tile renders with image placeholder before viewport intersection.
+- Status badge renders with correct color for each of the 3 states.
+- Click handler fires with the allocation object.
+- Component is typed with TypeScript strict mode (no implicit `any`).
+
+**Dependencies:** F1.
+
+---
+
+### Task F3: Implement `AllocationPopover` component [frontend]
+
+**File:** `frontend/src/components/AllocationPopover.tsx` (new file)
+
+**Description:**
+Popover anchored to the tile. Displayed when a tile is clicked (state managed in `CardAllocations` page). Receives:
+
+```typescript
+interface AllocationPopoverProps {
+  allocation: CardAllocation;
+  onRemoveFromDeck: (deckId: number, cardId: number) => void;
+  onClose: () => void;
+}
+```
+
+**Content:**
+- Card name as heading.
+- If `allocation.decks.length === 0`: message "Available — not in any deck".
+- If `allocation.decks.length >= 1`: list of decks, each with deck name and a "Remove" button.
+- Close button (or Escape key to dismiss).
+
+**Accessibility:**
+- `role="dialog"`, `aria-modal="true"`, `aria-label` = card name + " allocation details".
+- Trap focus within the popover while open (or use `AccessibleModal` if it supports the use case).
+- Escape key calls `onClose`.
+- "Remove" button has `aria-label="Remove from [deck name]"`.
+
+**Loading state for remove action:** Show a brief disabled state on the "Remove" button while the mutation is in-flight (use local `isPending` state set before the `onRemoveFromDeck` call resolves).
+
+**Acceptance criteria:**
+- Popover renders with correct content for 0-deck, 1-deck, and 2-deck cases.
+- Remove button calls `onRemoveFromDeck` with correct deckId and cardId.
+- Escape key and close button call `onClose`.
+- `role="dialog"` is present in the DOM.
+
+**Dependencies:** F1.
+
+---
+
+### Task F4: Implement `CardAllocations` page [frontend]
+
+**File:** `frontend/src/pages/CardAllocations.tsx` (new file)
+
+**Description:**
+Main page component for `/allocations`.
+
+```typescript
+export function CardAllocations() { ... }
+```
+
+**Behavior:**
+- `useQuery(['card-allocations'], api.getCardAllocations)` — loads allocation data.
+- Shows a loading spinner while fetching.
+- On HTTP 501 (no Postgres): shows a user-friendly message (not an error toast) explaining that deck features require Postgres/DATABASE_URL.
+- On other errors: shows a generic error message.
+- Grid: `grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3` (same breakpoints as `CardGallery`).
+- Renders one `AllocationTile` per `CardAllocation`.
+- State: `selectedAllocation: CardAllocation | null` — set when tile is clicked, cleared on popover close.
+- When `selectedAllocation` is set: renders `AllocationPopover`.
+- `onRemoveFromDeck` handler:
+  1. Calls `api.removeDeckCard(deckId, cardId)` (already exists in client).
+  2. On success: calls `queryClient.invalidateQueries({ queryKey: ['card-allocations'] })`.
+  3. On error: shows error toast or inline message.
+  4. Clears `selectedAllocation` after successful removal (popover closes).
+
+**Page header:** Title "Card Allocations", brief subtitle "See where each card is used across your decks."
+
+**Acceptance criteria:**
+- Page renders grid with status badges for all cards.
+- Clicking a tile opens the popover for that card.
+- Removing from a deck via popover triggers cache invalidation and the badge updates on next render.
+- 501 response shows informative message instead of error.
+- TypeScript strict mode, no implicit `any`.
+
+**Dependencies:** F2, F3, F1.
+
+---
+
+## Phase 4 — Navigation and Routing
+
+### Task F5: Add nav link and route for `/allocations` [frontend]
+
+**Files:**
+- `frontend/src/components/Navbar.tsx`
+- `frontend/src/App.tsx` (or wherever routes are defined)
+- `frontend/src/locales/en.json`
+- `frontend/src/locales/es.json`
+
+**Description:**
+
+In `Navbar.tsx`, add to `navLinks` array (after the Decks link, before Analytics):
+```typescript
+{ path: '/allocations', label: t('navbar.allocations'), badge: 'alpha' },
+```
+
+In `App.tsx` (inside the authenticated/protected route tree):
+```tsx
+import { CardAllocations } from './pages/CardAllocations';
+// ...
+<Route path="/allocations" element={<ProtectedRoute><CardAllocations /></ProtectedRoute>} />
+```
+
+In `en.json` and `es.json`, add:
+```json
+"navbar": {
+  "allocations": "Allocations"
+}
+```
+(Spanish: `"Asignaciones"`)
+
+**Acceptance criteria:**
+- "Allocations" link appears in the navbar between Decks and Analytics.
+- Link has an "alpha" badge styled identically to the "Decks" alpha badge.
+- Navigating to `/allocations` renders the `CardAllocations` page (not a 404 or redirect).
+- Unauthenticated users navigating to `/allocations` are redirected to `/login` by `ProtectedRoute`.
+- i18n keys exist in both `en.json` and `es.json`.
+
+**Dependencies:** F4.
+
+---
+
+## Phase 5 — Frontend Tests
+
+### Task F6: Unit tests for `getAllocationStatus` and `AllocationTile` [frontend]
+
+**File:** `frontend/src/components/__tests__/AllocationTile.test.tsx` (new file)
+
+**Description:**
+Use Vitest + Testing Library.
+
+Tests:
+1. `getAllocationStatus(0)` returns `'available'`.
+2. `getAllocationStatus(1)` returns `'assigned'`.
+3. `getAllocationStatus(3)` returns `'shared'`.
+4. `AllocationTile` renders with `available` status → green badge is in the DOM.
+5. `AllocationTile` renders with `assigned` status → orange badge is in the DOM.
+6. `AllocationTile` renders with `shared` status → red badge is in the DOM.
+7. Clicking tile calls `onTileClick` with the correct allocation object.
+
+Mock `useImageCache` to return a stable src (avoids IntersectionObserver setup in tests).
+
+**Acceptance criteria:**
+- All 7 tests pass with `npm run test` (or `vitest run`).
+- No real network calls or DOM image loading.
+
+**Dependencies:** F2.
+
+---
+
+### Task F7: Unit tests for `AllocationPopover` [frontend]
+
+**File:** `frontend/src/components/__tests__/AllocationPopover.test.tsx` (new file)
+
+**Description:**
+Tests:
+1. Renders "Available — not in any deck" when `allocation.decks` is empty.
+2. Renders deck name(s) when `allocation.decks` has entries.
+3. Clicking a "Remove" button calls `onRemoveFromDeck` with correct `(deckId, cardId)`.
+4. Clicking close button calls `onClose`.
+5. Pressing Escape calls `onClose`.
+6. `role="dialog"` is present.
+
+**Acceptance criteria:**
+- All 6 tests pass.
+- No real API calls (mock `onRemoveFromDeck` as a jest/vitest spy).
+
+**Dependencies:** F3.
+
+---
+
+### Task F8: Integration test for `CardAllocations` page [frontend]
+
+**File:** `frontend/src/pages/__tests__/CardAllocations.test.tsx` (new file)
+
+**Description:**
+Tests:
+1. Shows loading state while query is in-flight.
+2. Renders correct number of tiles after data loads (mock API response).
+3. Clicking a tile opens the popover for that card.
+4. 501 response renders informative message (not an error boundary crash).
+5. Remove action calls `api.removeDeckCard` and invalidates cache.
+
+Mock `api.getCardAllocations` and `api.removeDeckCard` using Vitest's module mock. Mock `useImageCache` to return a stable image src.
+
+**Acceptance criteria:**
+- All 5 tests pass.
+- No real HTTP requests in tests.
+- Query client is wrapped in a `QueryClientProvider` in test setup.
+
+**Dependencies:** F4, F5.

--- a/openspec/changes/archive/2026-03-16-deck-power-level-estimation/confidence-score.json
+++ b/openspec/changes/archive/2026-03-16-deck-power-level-estimation/confidence-score.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1",
+  "change": "deck-power-level-estimation",
+  "agent": "reviewer",
+  "scored_at": "2026-03-16T08:00:00Z",
+  "overall": 84,
+  "aspects": {
+    "type_correctness": 88,
+    "pattern_adherence": 85,
+    "test_coverage": 80,
+    "security": 85,
+    "architectural_alignment": 83
+  },
+  "notes": {
+    "type_correctness": "PowerLevelBreakdownResponse duplicates FactorBreakdown (informational, not a type error). PowerLevelBadge and scoring engine types are consistent.",
+    "pattern_adherence": "set_commander now bumps updated_at consistently with add_card, remove_card, add_cards_batch — the omission was a deviation from the established pattern, now fixed.",
+    "test_coverage": "Scoring engine logic has unit tests. The unbounded cache noted by security reviewer lacks a cache-eviction test. Integration coverage for the /power-level endpoint is present.",
+    "security": "Unbounded power level cache is low risk for current deployment scale. Card ID in 404 messages is informational. No CRITICAL findings.",
+    "architectural_alignment": "Scoring engine is in deckdex/ core, API in backend/ routes, badge in frontend. Layer separation is correct."
+  },
+  "flags": ["unbounded-power-level-cache"]
+}

--- a/openspec/changes/archive/2026-03-16-deck-power-level-estimation/context-bundle.md
+++ b/openspec/changes/archive/2026-03-16-deck-power-level-estimation/context-bundle.md
@@ -1,0 +1,632 @@
+# Context Bundle: Deck Power Level Auto-Estimation
+
+This file collects the exact code context, file paths, and concrete change snippets an implementer needs without having to read the full codebase. Read design.md for the full rationale.
+
+---
+
+## 1. New Files to Create
+
+### `deckdex/services/__init__.py`
+
+Check whether this directory and `__init__.py` exist first. If `deckdex/services/` does not exist:
+
+```bash
+mkdir -p deckdex/services
+touch deckdex/services/__init__.py
+```
+
+### `deckdex/services/power_level.py`
+
+Complete implementation skeleton:
+
+```python
+"""
+Heuristic power level estimation for Commander decks.
+
+Pure computation — no I/O, no database access.
+Input: list of card dicts as returned by DeckRepository.get_deck_with_cards() → deck["cards"]
+  Relevant keys: name, description (oracle text), type (type_line), cmc, edhrec_rank, quantity, is_commander
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Curated card sets (all lowercase)
+# ---------------------------------------------------------------------------
+
+FAST_MANA: frozenset[str] = frozenset({
+    "sol ring", "mana crypt", "mana vault", "chrome mox", "mox diamond",
+    "mox opal", "lotus petal", "dark ritual", "cabal ritual",
+    "elvish spirit guide", "simian spirit guide", "ancient tomb",
+    "gaea's cradle", "serra's sanctum", "mishra's workshop",
+    "jeweled lotus", "lotus bloom", "mox amber",
+    "mana drain", "dockside extortionist",
+    "vault of whispers", "seat of the synod", "tree of tales",
+    "great furnace", "ancient den", "darksteel citadel",
+})
+
+COMBO_PIECES: frozenset[str] = frozenset({
+    "thassa's oracle", "demonic consultation", "tainted pact",
+    "laboratory maniac", "jace, wielder of mysteries",
+    "isochron scepter", "dramatic reversal",
+    "staff of domination", "umbral mantle", "sword of the paruns",
+    "basalt monolith", "rings of brighthearth",
+    "splinter twin", "kiki-jiki, mirror breaker",
+    "devoted druid", "vizier of remedies",
+    "heliod, sun-crowned", "walking ballista",
+    "necropotence", "ad nauseam",
+})
+
+PREMIUM_LANDS: frozenset[str] = frozenset({
+    # Original dual lands
+    "tundra", "underground sea", "badlands", "taiga", "savannah",
+    "scrubland", "volcanic island", "bayou", "plateau", "tropical island",
+    # Shock lands
+    "hallowed fountain", "watery grave", "blood crypt", "stomping ground",
+    "temple garden", "godless shrine", "steam vents", "overgrown tomb",
+    "sacred foundry", "breeding pool",
+    # Fetch lands (Onslaught + Zendikar cycles)
+    "flooded strand", "polluted delta", "bloodstained mire", "wooded foothills",
+    "windswept heath", "marsh flats", "scalding tarn", "verdant catacombs",
+    "arid mesa", "misty rainforest",
+    # Zendikar battle lands
+    "prairie stream", "sunken hollow", "smoldering marsh", "cinder glade",
+    "canopy vista", "shambling vent", "wandering fumarole", "needle spires",
+    "hissing quagmire", "lumbering falls",
+})
+
+# ---------------------------------------------------------------------------
+# Bracket mapping
+# ---------------------------------------------------------------------------
+
+_BRACKET_THRESHOLDS = [(8.0, 4), (6.0, 3), (4.0, 2)]
+
+
+def _compute_bracket(score: float) -> int:
+    for threshold, bracket in _BRACKET_THRESHOLDS:
+        if score >= threshold:
+            return bracket
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+class FactorBreakdown(BaseModel):
+    fast_mana: float
+    tutors: float
+    combo_pieces: float
+    avg_cmc: float
+    land_quality: float
+    staple_density: float
+
+
+class PowerLevelResult(BaseModel):
+    score: float
+    bracket: int
+    summary: str
+    breakdown: FactorBreakdown
+
+
+# ---------------------------------------------------------------------------
+# Individual signal scorers
+# ---------------------------------------------------------------------------
+
+def _score_fast_mana(cards: list[dict[str, Any]]) -> float:
+    count = sum(1 for c in cards if str(c.get("name", "")).lower() in FAST_MANA)
+    return min(count / 4.0, 1.0)
+
+
+def _score_tutors(cards: list[dict[str, Any]]) -> float:
+    count = sum(
+        1 for c in cards
+        if "search your library" in str(c.get("description", "")).lower()
+    )
+    return min(count / 5.0, 1.0)
+
+
+def _score_combo_pieces(cards: list[dict[str, Any]]) -> float:
+    count = sum(
+        1 for c in cards
+        if (
+            str(c.get("name", "")).lower() in COMBO_PIECES
+            or "infinite" in str(c.get("description", "")).lower()
+        )
+    )
+    return min(count / 3.0, 1.0)
+
+
+def _score_avg_cmc(cards: list[dict[str, Any]]) -> float:
+    non_lands = [
+        c for c in cards
+        if "land" not in str(c.get("type", "")).lower()
+    ]
+    if not non_lands:
+        return 0.5
+    total_cmc = sum(
+        float(c.get("cmc") or 0) * int(c.get("quantity") or 1)
+        for c in non_lands
+    )
+    count = sum(int(c.get("quantity") or 1) for c in non_lands)
+    avg = total_cmc / count if count > 0 else 3.5
+    if avg <= 1.5:
+        return 1.0
+    elif avg <= 2.0:
+        return 0.85
+    elif avg <= 2.5:
+        return 0.70
+    elif avg <= 3.0:
+        return 0.55
+    elif avg <= 3.5:
+        return 0.40
+    elif avg <= 4.0:
+        return 0.25
+    else:
+        return 0.10
+
+
+def _score_land_quality(cards: list[dict[str, Any]]) -> float:
+    count = sum(1 for c in cards if str(c.get("name", "")).lower() in PREMIUM_LANDS)
+    return min(count / 10.0, 1.0)
+
+
+def _score_staple_density(cards: list[dict[str, Any]]) -> float:
+    """Cards with EDHREC rank <= 50 are considered high-impact staples."""
+    count = 0
+    for c in cards:
+        rank = c.get("edhrec_rank")
+        if rank is not None:
+            try:
+                if int(rank) <= 50:
+                    count += 1
+            except (ValueError, TypeError):
+                pass
+    return min(count / 10.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Summary string builder
+# ---------------------------------------------------------------------------
+
+_POWER_ADJECTIVES = {
+    (1, 3): "casual",
+    (4, 5): "mid-power",
+    (6, 7): "strong",
+    (8, 10): "highly optimised",
+}
+
+_FACTOR_LABELS = {
+    "fast_mana": "fast mana",
+    "tutors": "tutors",
+    "combo_pieces": "combo pieces",
+    "avg_cmc": "low curve",
+    "land_quality": "premium mana base",
+    "staple_density": "high-impact staples",
+}
+
+
+def _build_summary(score: float, breakdown: FactorBreakdown) -> str:
+    score_int = round(score)
+    adjective = "mid-power"
+    for (lo, hi), adj in _POWER_ADJECTIVES.items():
+        if lo <= score_int <= hi:
+            adjective = adj
+            break
+
+    scores_dict = breakdown.model_dump()
+    positives = [_FACTOR_LABELS[k] for k, v in scores_dict.items() if v >= 0.7]
+    absences = [_FACTOR_LABELS[k] for k, v in scores_dict.items() if v == 0.0]
+
+    parts = [f"{score_int} \u2014 {adjective} deck"]
+    if positives:
+        parts.append(f"with {', '.join(positives[:2])}")
+    if absences:
+        parts.append(f"but no {absences[0]}")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+_WEIGHTS = {
+    "fast_mana": 2.5,
+    "tutors": 2.0,
+    "combo_pieces": 2.0,
+    "avg_cmc": 1.5,
+    "land_quality": 1.0,
+    "staple_density": 1.0,
+}
+_TOTAL_WEIGHT = sum(_WEIGHTS.values())  # 10.0
+
+
+def estimate_power_level(cards: list[dict[str, Any]]) -> PowerLevelResult:
+    """Compute a heuristic power level score for a Commander deck.
+
+    Args:
+        cards: List of card dicts from DeckRepository.get_deck_with_cards().
+               Keys used: name, description, type, cmc, edhrec_rank, quantity.
+
+    Returns:
+        PowerLevelResult with score (1–10), bracket (1–4), summary, and breakdown.
+    """
+    if not cards:
+        breakdown = FactorBreakdown(
+            fast_mana=0.0, tutors=0.0, combo_pieces=0.0,
+            avg_cmc=0.5, land_quality=0.0, staple_density=0.0,
+        )
+        return PowerLevelResult(score=1.0, bracket=1, summary="1 — no cards in deck", breakdown=breakdown)
+
+    breakdown = FactorBreakdown(
+        fast_mana=_score_fast_mana(cards),
+        tutors=_score_tutors(cards),
+        combo_pieces=_score_combo_pieces(cards),
+        avg_cmc=_score_avg_cmc(cards),
+        land_quality=_score_land_quality(cards),
+        staple_density=_score_staple_density(cards),
+    )
+
+    scores_dict = breakdown.model_dump()
+    raw = sum(_WEIGHTS[k] * scores_dict[k] for k in _WEIGHTS) / _TOTAL_WEIGHT
+    score = round(max(1.0, min(10.0, raw * 10)), 1)
+    bracket = _compute_bracket(score)
+    summary = _build_summary(score, breakdown)
+
+    return PowerLevelResult(score=score, bracket=bracket, summary=summary, breakdown=breakdown)
+```
+
+---
+
+### `backend/api/services/power_level_service.py`
+
+```python
+"""Caching service layer for deck power level estimation."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from deckdex.services.power_level import PowerLevelResult, estimate_power_level
+from deckdex.storage.deck_repository import DeckRepository
+
+_cache: dict[tuple, tuple[PowerLevelResult, datetime]] = {}
+_CACHE_TTL_SECONDS = 300
+
+
+def _cache_key(deck: dict, user_id: int) -> tuple:
+    return (
+        deck["id"],
+        user_id,
+        len(deck.get("cards", [])),
+        deck.get("updated_at", ""),
+    )
+
+
+def get_power_level(deck_id: int, repo: DeckRepository, user_id: int) -> Optional[PowerLevelResult]:
+    """Return cached or freshly computed power level for a deck.
+
+    Returns None if the deck does not exist or does not belong to the user.
+    """
+    deck = repo.get_deck_with_cards(deck_id, user_id=user_id)
+    if deck is None:
+        return None
+
+    key = _cache_key(deck, user_id)
+    now = datetime.now(tz=timezone.utc)
+
+    if key in _cache:
+        result, cached_at = _cache[key]
+        if (now - cached_at).total_seconds() < _CACHE_TTL_SECONDS:
+            return result
+
+    result = estimate_power_level(deck.get("cards", []))
+    _cache[key] = (result, now)
+    return result
+```
+
+---
+
+## 2. Files to Modify
+
+### `backend/api/routes/decks.py`
+
+**After the existing imports**, add:
+
+```python
+# (no new top-level imports needed; power_level_service is imported inside the handler)
+```
+
+**After the existing Pydantic models** (after `BatchAddResult`), add:
+
+```python
+class PowerLevelBreakdownResponse(BaseModel):
+    fast_mana: float
+    tutors: float
+    combo_pieces: float
+    avg_cmc: float
+    land_quality: float
+    staple_density: float
+
+
+class PowerLevelResponse(BaseModel):
+    score: float
+    bracket: int
+    summary: str
+    breakdown: PowerLevelBreakdownResponse
+```
+
+**After the `import_deck_text` route** (end of file), add:
+
+```python
+@router.get("/{deck_id}/power-level", response_model=PowerLevelResponse)
+async def get_deck_power_level(
+    deck_id: int,
+    repo: DeckRepository = Depends(require_deck_repo),
+    user_id: int = Depends(get_current_user_id),
+):
+    """Return heuristic power level score and Commander Bracket for a deck."""
+    from ..services.power_level_service import get_power_level
+
+    result = get_power_level(deck_id, repo, user_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    return result
+```
+
+---
+
+### `frontend/src/api/client.ts`
+
+**After `BatchAddResult` interface** (line ~187), insert:
+
+```typescript
+export interface PowerLevelBreakdown {
+  fast_mana: number;
+  tutors: number;
+  combo_pieces: number;
+  avg_cmc: number;
+  land_quality: number;
+  staple_density: number;
+}
+
+export interface PowerLevelResponse {
+  score: number;
+  bracket: number;
+  summary: string;
+  breakdown: PowerLevelBreakdown;
+}
+```
+
+**Inside the `api` object, after `importDeckText`** (line ~834), insert:
+
+```typescript
+  getDeckPowerLevel: async (deckId: number): Promise<PowerLevelResponse> => {
+    const response = await apiFetch(`${API_BASE}/decks/${deckId}/power-level`);
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      if (response.status === 404) throw new Error('Deck not found');
+      if (response.status === 501) throw new Error((err as { detail?: string }).detail || 'Decks require Postgres');
+      throw new Error((err as { detail?: string }).detail || 'Failed to fetch power level');
+    }
+    return response.json();
+  },
+```
+
+---
+
+### `frontend/src/pages/DeckBuilder.tsx` — `DeckCardButton` component
+
+Add `useQuery` import (already imported elsewhere in the file).
+
+**Inside `DeckCardButton`** (after `const { src: commanderImageUrl } = useCardImage(...)`):
+
+```typescript
+  const { data: powerLevel } = useQuery({
+    queryKey: ['deckPowerLevel', deck.id],
+    queryFn: () => api.getDeckPowerLevel(deck.id),
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const BRACKET_COLORS: Record<number, string> = {
+    1: 'bg-green-600',
+    2: 'bg-blue-600',
+    3: 'bg-orange-500',
+    4: 'bg-red-600',
+  };
+```
+
+**Inside the returned JSX** (inside the `<button>`, after the card count `<span>`):
+
+```tsx
+      {powerLevel && (
+        <span
+          className={`absolute bottom-2 right-2 z-20 text-white text-xs font-semibold px-1.5 py-0.5 rounded ${BRACKET_COLORS[powerLevel.bracket] ?? 'bg-gray-600'}`}
+          title={powerLevel.summary}
+        >
+          B{powerLevel.bracket} · {powerLevel.score.toFixed(1)}
+        </span>
+      )}
+```
+
+---
+
+### `frontend/src/components/DeckDetailModal.tsx`
+
+**After existing `useQuery` / `useQueryClient` imports**, no new imports needed (already uses `useQuery`).
+
+**After `const [copyFeedback, setCopyFeedback] = useState(false)`** (inside the component body), add:
+
+```typescript
+  const { data: powerLevel } = useQuery({
+    queryKey: ['deckPowerLevel', deckId],
+    queryFn: () => api.getDeckPowerLevel(deckId),
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const BRACKET_LABELS: Record<number, string> = {
+    1: 'Casual', 2: 'Mid Power', 3: 'High Power', 4: 'Optimised',
+  };
+  const bracketTextColor = (b: number): string => {
+    if (b === 1) return 'text-green-500';
+    if (b === 2) return 'text-blue-500';
+    if (b === 3) return 'text-orange-500';
+    return 'text-red-500';
+  };
+```
+
+**In the modal header JSX** (after the mana curve `<ResponsiveContainer>` block, before the action buttons), insert:
+
+```tsx
+              {powerLevel && (
+                <div
+                  className="flex flex-col items-center shrink-0 cursor-help px-2"
+                  title={powerLevel.summary}
+                >
+                  <span className={`text-lg font-bold leading-none ${bracketTextColor(powerLevel.bracket)}`}>
+                    {powerLevel.score.toFixed(1)}
+                  </span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap mt-0.5">
+                    {BRACKET_LABELS[powerLevel.bracket]} · B{powerLevel.bracket}
+                  </span>
+                </div>
+              )}
+```
+
+---
+
+## 3. Existing Files — Context Only (No Changes)
+
+| File | Why relevant |
+|------|-------------|
+| `deckdex/storage/repository.py` | `_row_to_card` defines the dict shape the scoring engine receives; note `"description"` for oracle_text, `"type"` for type_line |
+| `deckdex/storage/deck_repository.py` | `get_deck_with_cards` is the data source; no changes needed for core feature |
+| `backend/api/dependencies.py` | `get_current_user_id`, `get_deck_repo` — imported as-is in the new endpoint |
+| `backend/api/main.py` | No router registration needed; `decks.router` is already included |
+| `frontend/src/hooks/useCardImage.ts` | Pattern reference for lazy image fetching inside a tile component |
+
+---
+
+## 4. Card Dict Field Mapping Reference
+
+The `_row_to_card` function in `deckdex/storage/repository.py` maps database columns to these dict keys:
+
+| DB column     | Dict key        | Used in scoring |
+|---------------|-----------------|-----------------|
+| `name`        | `"name"`        | Yes (fast mana, combos, premium lands) |
+| `description` | `"description"` | Yes (tutors, combo oracle text) |
+| `type_line`   | `"type"`        | Yes (avg CMC: exclude lands) |
+| `cmc`         | `"cmc"`         | Yes |
+| `edhrec_rank` | `"edhrec_rank"` | Yes (staple density) |
+| `quantity`    | `"quantity"`    | Yes (weighted avg CMC) |
+| `is_commander`| `"is_commander"`| No (not used in scoring) |
+
+**Critical**: use `"description"` not `"oracle_text"`, and `"type"` not `"type_line"` when accessing card dicts in `power_level.py`.
+
+---
+
+## 5. Test File Skeleton
+
+### `tests/test_power_level.py`
+
+```python
+"""Unit tests for deckdex/services/power_level.py"""
+import pytest
+from deckdex.services.power_level import (
+    estimate_power_level,
+    _compute_bracket,
+    _build_summary,
+    FactorBreakdown,
+)
+
+
+def _card(name: str, description: str = "", type_: str = "Instant", cmc: float = 2.0, edhrec_rank: int = 999) -> dict:
+    return {"name": name, "description": description, "type": type_, "cmc": cmc, "edhrec_rank": edhrec_rank, "quantity": 1}
+
+
+@pytest.fixture()
+def empty_deck():
+    return []
+
+
+@pytest.fixture()
+def fast_mana_deck():
+    return [
+        _card("Sol Ring", cmc=1),
+        _card("Mana Crypt", cmc=0),
+        _card("Mana Vault", cmc=1),
+        _card("Chrome Mox", cmc=0),
+    ]
+
+
+@pytest.fixture()
+def tutor_deck():
+    return [
+        _card("Demonic Tutor", description="Search your library for a card"),
+        _card("Vampiric Tutor", description="Search your library for a card"),
+        _card("Enlightened Tutor", description="Search your library for a card"),
+        _card("Imperial Seal", description="Search your library for a card"),
+        _card("Mystical Tutor", description="Search your library for a card"),
+    ]
+
+
+class TestEmptyDeck:
+    def test_score_is_one(self, empty_deck):
+        result = estimate_power_level(empty_deck)
+        assert result.score == 1.0
+
+    def test_bracket_is_one(self, empty_deck):
+        result = estimate_power_level(empty_deck)
+        assert result.bracket == 1
+
+
+class TestFastMana:
+    def test_four_fast_mana_cards_max_factor(self, fast_mana_deck):
+        result = estimate_power_level(fast_mana_deck)
+        assert result.breakdown.fast_mana == 1.0
+
+    def test_score_elevated(self, fast_mana_deck):
+        result = estimate_power_level(fast_mana_deck)
+        assert result.score >= 4.0
+
+
+class TestTutors:
+    def test_five_tutors_max_factor(self, tutor_deck):
+        result = estimate_power_level(tutor_deck)
+        assert result.breakdown.tutors == 1.0
+
+
+class TestComputeBracket:
+    @pytest.mark.parametrize("score,expected", [
+        (1.0, 1), (3.0, 1), (3.9, 1),
+        (4.0, 2), (5.9, 2),
+        (6.0, 3), (7.9, 3),
+        (8.0, 4), (10.0, 4),
+    ])
+    def test_bracket_thresholds(self, score, expected):
+        assert _compute_bracket(score) == expected
+
+
+class TestBuildSummary:
+    def test_returns_non_empty_string(self):
+        bd = FactorBreakdown(
+            fast_mana=0.5, tutors=0.2, combo_pieces=0.0,
+            avg_cmc=0.7, land_quality=0.6, staple_density=0.3,
+        )
+        result = _build_summary(6.5, bd)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_score_appears_in_summary(self):
+        bd = FactorBreakdown(
+            fast_mana=0.0, tutors=0.0, combo_pieces=0.0,
+            avg_cmc=0.5, land_quality=0.0, staple_density=0.0,
+        )
+        result = _build_summary(3.0, bd)
+        assert "3" in result
+```

--- a/openspec/changes/archive/2026-03-16-deck-power-level-estimation/delta-spec.md
+++ b/openspec/changes/archive/2026-03-16-deck-power-level-estimation/delta-spec.md
@@ -1,0 +1,72 @@
+# Delta Spec: Deck Power Level Auto-Estimation
+
+This document records the additive changes to existing specs. No existing requirements are removed or modified.
+
+---
+
+## Changes to `openspec/specs/decks/spec.md`
+
+### ADD: Requirement — Power level estimation endpoint
+
+> The system SHALL expose `GET /api/decks/{deck_id}/power-level` (auth required, 501 if Postgres unavailable). The endpoint SHALL compute a heuristic power level score for the deck using only data already stored in the `cards` table (card names, oracle text, CMC, EDHREC rank). The response SHALL include:
+>
+> - `score` (float, 1.0–10.0): composite power rating
+> - `bracket` (int, 1–4): Commander Bracket mapping derived from score
+> - `summary` (string): one-sentence human-readable explanation (e.g. "7 — strong tempo deck with premium mana base but few tutors")
+> - `breakdown` (object): per-factor normalized scores for fast_mana, tutors, combo_pieces, avg_cmc, land_quality, staple_density
+>
+> The endpoint SHALL NOT require any external API calls. The endpoint SHALL return 404 if the deck does not exist or does not belong to the authenticated user.
+
+#### Scenario: Fetch power level for a valid deck
+
+- **WHEN** the authenticated user calls `GET /api/decks/{deck_id}/power-level` for a deck they own
+- **THEN** the API returns HTTP 200 with a JSON body containing `score`, `bracket`, `summary`, and `breakdown`
+
+#### Scenario: Deck not found
+
+- **WHEN** the authenticated user calls `GET /api/decks/{deck_id}/power-level` with a deck_id that does not exist or belongs to another user
+- **THEN** the API returns HTTP 404
+
+#### Scenario: Postgres not configured
+
+- **WHEN** no `DATABASE_URL` is set and the endpoint is called
+- **THEN** the API returns HTTP 501 with the standard Postgres-required message
+
+---
+
+## Changes to `openspec/specs/deck-builder-ui/spec.md`
+
+### ADD: Requirement — Power level badge on deck tile
+
+> Each deck tile in the deck grid SHALL display a power level badge showing the numeric score and bracket (e.g. "B3 · 7.2"). The badge SHALL use a colour indicating the bracket: green for bracket 1, blue for bracket 2, orange for bracket 3, red for bracket 4. The badge SHALL be fetched asynchronously; it SHALL be absent (not an error state) while loading or on fetch failure.
+
+#### Scenario: Badge appears on loaded deck tile
+
+- **WHEN** the user views the deck grid and the power level has loaded for a deck
+- **THEN** the deck tile shows a small coloured badge with the bracket and score (e.g. "B3 · 7.2")
+
+#### Scenario: Badge absent while loading
+
+- **WHEN** the power level request is in-flight or has failed
+- **THEN** the tile renders normally without a badge (no spinner, no error state visible)
+
+---
+
+### ADD: Requirement — Power level section in deck detail modal
+
+> The DeckDetailModal SHALL include a "Power Level" display in the header area. It SHALL show: the numeric score styled with the bracket colour, the bracket label (e.g. "High Power · B3"), and on hover a tooltip containing the full summary string and a mini-table of per-factor breakdown scores. The section SHALL render as an invisible placeholder while loading and be omitted gracefully on fetch error.
+
+#### Scenario: Power level displayed in detail modal
+
+- **WHEN** the user opens a deck detail modal and the power level has loaded
+- **THEN** the header area shows the score and bracket label with appropriate colour coding
+
+#### Scenario: Hovering power level shows breakdown
+
+- **WHEN** the user hovers over the power level display in the deck detail modal
+- **THEN** a tooltip appears showing the full summary sentence and per-factor scores (fast_mana, tutors, combo_pieces, avg_cmc, land_quality, staple_density)
+
+#### Scenario: Power level gracefully absent on error
+
+- **WHEN** the power level fetch fails (network error or backend unavailable)
+- **THEN** the deck detail modal renders fully without the power level section; no error message is shown to the user for this non-critical feature

--- a/openspec/changes/archive/2026-03-16-deck-power-level-estimation/design.md
+++ b/openspec/changes/archive/2026-03-16-deck-power-level-estimation/design.md
@@ -1,0 +1,359 @@
+# Technical Design: Deck Power Level Auto-Estimation
+
+---
+
+## Architecture Overview
+
+```
+GET /api/decks/{deck_id}/power-level
+        |
+        v
+backend/api/routes/decks.py (new endpoint, auth guard)
+        |
+        v
+backend/api/services/power_level_service.py   <-- thin adapter/cache layer
+        |
+        v
+deckdex/services/power_level.py               <-- pure scoring engine (no I/O)
+        |
+        v
+DeckRepository.get_deck_with_cards()          <-- existing data access (no new queries)
+```
+
+The scoring engine (`deckdex/services/power_level.py`) receives a pre-loaded list of card dicts (identical to the structure already returned by `get_deck_with_cards`) and returns a structured result. It performs zero database access — all I/O is handled by the route handler.
+
+---
+
+## Scoring Algorithm
+
+### Signal Definitions
+
+The engine scores the following six signals, each producing a normalized contribution (0.0–1.0) that feeds into the final weighted sum.
+
+#### 1. Fast Mana Density (weight: 2.5)
+
+Fast mana is the single strongest power indicator. Cards producing mana acceleration in the first two turns compress the effective game speed of the entire deck.
+
+**Detection**: card `name` exact-match against a curated set. Using name matching (not oracle text) is intentional: oracle text varies across printings, and name is the canonical identifier.
+
+```
+FAST_MANA = {
+    "sol ring", "mana crypt", "mana vault", "chrome mox", "mox diamond",
+    "mox opal", "lotus petal", "dark ritual", "cabal ritual", "elvish spirit guide",
+    "simian spirit guide", "ancient tomb", "gaea's cradle", "serra's sanctum",
+    "mishra's workshop", "jeweled lotus", "lotus bloom", "mox amber",
+    "mana drain",           # free counterspell that produces mana
+    "dockside extortionist", # conditional but ubiquitous
+    "vault of whispers", "seat of the synod", "tree of tales",  # artifact lands
+    "great furnace", "ancient den", "darksteel citadel",
+}
+```
+
+Score = min(fast_mana_count / 4.0, 1.0)
+- 0 fast mana cards → 0.0
+- 1 card → 0.25
+- 4+ cards → 1.0 (capped)
+
+#### 2. Tutor Density (weight: 2.0)
+
+Tutors compress variance, converting a 99-card random sample into an on-demand toolbox.
+
+**Detection**: oracle_text substring search for "search your library" (case-insensitive). This matches all Demonic Tutor variants, Enlightened Tutor, Vampiric Tutor, Imperial Seal, etc. False positives (fetchlands, basic land cyclers) are acceptable noise at this level; they genuinely do provide consistency.
+
+Score = min(tutor_count / 5.0, 1.0)
+- 0 tutors → 0.0
+- 5+ tutors → 1.0
+
+#### 3. Combo Infrastructure (weight: 2.0)
+
+Two-card infinite combos dramatically raise the threat ceiling of any deck.
+
+**Detection**: keyword presence + oracle text patterns. The engine checks for cards that:
+- Contain "infinite" in oracle_text, OR
+- Are well-known combo enablers by name:
+
+```
+COMBO_PIECES = {
+    "thassa's oracle", "demonic consultation", "tainted pact",
+    "thoracle",         # alias handled by name normalisation
+    "labman",           # Laboratory Maniac
+    "laboratory maniac", "jace, wielder of mysteries",
+    "isochron scepter", "dramatic reversal",
+    "staff of domination", "umbral mantle", "sword of the paruns",
+    "basalt monolith", "rings of brighthearth",
+    "splinter twin", "kiki-jiki, mirror breaker",
+    "devoted druid", "vizier of remedies",
+    "heliod, sun-crowned", "walking ballista",
+    "necropotence", "ad nauseam",   # storm enablers / near-combo
+}
+```
+
+Score = min(combo_count / 3.0, 1.0)
+- 0 combo pieces → 0.0
+- 3+ → 1.0
+
+#### 4. Average CMC (weight: 1.5)
+
+Lower average CMC correlates with tempo and resilience. Measured on non-land cards only.
+
+Scoring table:
+- avg_cmc <= 1.5 → 1.0
+- avg_cmc <= 2.0 → 0.85
+- avg_cmc <= 2.5 → 0.70
+- avg_cmc <= 3.0 → 0.55
+- avg_cmc <= 3.5 → 0.40
+- avg_cmc <= 4.0 → 0.25
+- avg_cmc > 4.0 → 0.10
+
+#### 5. Land Base Quality (weight: 1.0)
+
+Shock lands, fetch lands, and dual lands provide reliable, early mana fixing that enables consistent fast starts.
+
+**Detection**: name exact-match against curated set covering the ten original duals, ten shocklands, ten fetchlands, and the ten Zendikar battle lands.
+
+Score = min(premium_land_count / 10.0, 1.0)
+- 0 premium lands → 0.0
+- 10+ → 1.0
+
+#### 6. Staple Density (weight: 1.0)
+
+Well-known high-power staples that don't fit the categories above.
+
+**Detection**: EDHREC rank (already stored in `cards.edhrec_rank`). Cards with edhrec_rank <= 50 are considered staples.
+
+Score = min(staple_count / 10.0, 1.0)
+
+---
+
+### Composite Score Calculation
+
+```
+raw = (
+    fast_mana_score  * 2.5 +
+    tutor_score      * 2.0 +
+    combo_score      * 2.0 +
+    cmc_score        * 1.5 +
+    land_score       * 1.0 +
+    staple_score     * 1.0
+) / (2.5 + 2.0 + 2.0 + 1.5 + 1.0 + 1.0)  # = 10.0
+
+score = round(max(1.0, min(10.0, raw * 10)), 1)
+```
+
+Division by the sum of weights normalises the range to [0, 1]; multiply by 10 and clamp to [1, 10].
+
+---
+
+### Commander Bracket Mapping
+
+| Score | Bracket | Label          |
+|-------|---------|----------------|
+| 1–3   | 1       | Casual         |
+| 4–5   | 2       | Mid Power      |
+| 6–7   | 3       | High Power     |
+| 8–10  | 4       | Optimised/cEDH |
+
+---
+
+### Summary String Generation
+
+The summary is assembled from the dominant signals (those scoring above 0.5):
+
+```python
+def _build_summary(score, dominant_factors, avg_cmc):
+    # "7 — strong tempo deck with premium mana base but few tutors"
+```
+
+Template components:
+- Opening: `"{score:.0f} — "`
+- Power adjective: casual / mid-power / strong / highly optimised
+- Archetype hint from avg_cmc + land quality
+- Notable positives (signals >= 0.7)
+- Notable absences (expected signals that scored 0.0)
+
+---
+
+## New Files
+
+### `deckdex/services/power_level.py`
+
+Pure Python module with no dependencies beyond stdlib and the card dicts already provided by `get_deck_with_cards`. Accepts `List[Dict]` where each dict has keys: `name`, `oracle_text` (stored as `description` in DB), `type_line` (stored as `type`), `cmc`, `keywords`, `edhrec_rank`, `is_commander`, `quantity`.
+
+**Note on field name mapping**: The card dicts returned by `_row_to_card` in `repository.py` map DB column `description` → `"description"` (oracle text) and `type_line` → `"type"`. The service must use these aliased names.
+
+Public API:
+```python
+def estimate_power_level(cards: list[dict]) -> PowerLevelResult
+```
+
+`PowerLevelResult` is a Pydantic model (or dataclass) with:
+```python
+class FactorBreakdown(BaseModel):
+    fast_mana: float
+    tutors: float
+    combo_pieces: float
+    avg_cmc: float
+    land_quality: float
+    staple_density: float
+
+class PowerLevelResult(BaseModel):
+    score: float          # 1.0 – 10.0
+    bracket: int          # 1 – 4
+    summary: str          # "7 — strong tempo..."
+    breakdown: FactorBreakdown
+```
+
+### `backend/api/services/power_level_service.py`
+
+Thin service layer responsible for:
+1. Cache lookup (in-process dict keyed by `(deck_id, card_count, updated_at)`).
+2. Calling `repo.get_deck_with_cards()` when cache misses.
+3. Calling `deckdex.services.power_level.estimate_power_level()`.
+4. Storing result in cache with a 5-minute TTL.
+
+Cache key includes `card_count` and `updated_at` so any deck mutation (add/remove card, import) will produce a cache miss without an explicit invalidation call.
+
+```python
+_cache: dict[tuple, tuple[PowerLevelResult, datetime]] = {}
+_CACHE_TTL_SECONDS = 300
+
+def get_power_level(deck_id: int, repo: DeckRepository, user_id: int) -> PowerLevelResult | None:
+    ...
+```
+
+Returns `None` if the deck is not found (caller raises 404).
+
+---
+
+## New API Endpoint
+
+### `GET /api/decks/{deck_id}/power-level`
+
+**File**: `backend/api/routes/decks.py` (appended to existing router)
+
+**Auth**: `get_current_user_id` — same guard as all other deck endpoints.
+
+**Response model**:
+```python
+class PowerLevelResponse(BaseModel):
+    score: float
+    bracket: int
+    summary: str
+    breakdown: dict  # keys: fast_mana, tutors, combo_pieces, avg_cmc, land_quality, staple_density
+```
+
+**Status codes**:
+- 200: success
+- 404: deck not found or does not belong to user
+- 501: no Postgres configured (via `require_deck_repo`)
+
+**Example response**:
+```json
+{
+  "score": 7.2,
+  "bracket": 3,
+  "summary": "7 — strong tempo deck with premium mana base but few tutors",
+  "breakdown": {
+    "fast_mana": 0.75,
+    "tutors": 0.2,
+    "combo_pieces": 0.33,
+    "avg_cmc": 0.7,
+    "land_quality": 0.6,
+    "staple_density": 0.5
+  }
+}
+```
+
+---
+
+## Frontend Changes
+
+### `frontend/src/api/client.ts`
+
+Add new interface and API method:
+
+```typescript
+export interface PowerLevelBreakdown {
+  fast_mana: number;
+  tutors: number;
+  combo_pieces: number;
+  avg_cmc: number;
+  land_quality: number;
+  staple_density: number;
+}
+
+export interface PowerLevelResponse {
+  score: number;
+  bracket: number;
+  summary: string;
+  breakdown: PowerLevelBreakdown;
+}
+```
+
+```typescript
+getDeckPowerLevel: async (deckId: number): Promise<PowerLevelResponse> => {
+  const response = await apiFetch(`${API_BASE}/decks/${deckId}/power-level`);
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    if (response.status === 404) throw new Error('Deck not found');
+    if (response.status === 501) throw new Error((err as { detail?: string }).detail || 'Decks require Postgres');
+    throw new Error((err as { detail?: string }).detail || 'Failed to fetch power level');
+  }
+  return response.json();
+},
+```
+
+### `frontend/src/pages/DeckBuilder.tsx` — Power Level Badge on `DeckCardButton`
+
+`DeckCardButton` receives the `DeckListItem` which does not currently include power level data. Two options:
+
+**Option A (chosen)**: Fetch power level lazily per tile using `useQuery` inside `DeckCardButton`, keyed by `deck.id`. The call is made only when the tile is rendered. This avoids changing the `DeckListItem` type and keeps the badge self-contained.
+
+**Option B**: Batch fetch all power levels on page load. Requires a new batch endpoint. Deferred to a future optimisation.
+
+`DeckCardButton` additions:
+- New `useQuery` call: `queryKey: ['deckPowerLevel', deck.id]`, `queryFn: () => api.getDeckPowerLevel(deck.id)`.
+- Render a small badge in the bottom-right of the tile: bracket number + score, e.g. `B3 · 7.2`.
+- Badge styling: coloured pill using bracket-to-colour mapping:
+  - Bracket 1 → green (`bg-green-600`)
+  - Bracket 2 → blue (`bg-blue-600`)
+  - Bracket 3 → orange (`bg-orange-500`)
+  - Bracket 4 → red (`bg-red-600`)
+- While loading: render nothing (badge simply absent — avoids layout shift).
+- On error: render nothing (power level is non-critical; badge absence is acceptable degradation).
+
+### `frontend/src/components/DeckDetailModal.tsx` — Power Level Section
+
+A "Power Level" section is added to the modal header row, positioned after the mana curve and before the action buttons.
+
+Contents:
+- Large score number (e.g. "7.2") styled with the bracket colour.
+- Bracket label (e.g. "High Power · B3").
+- Tooltip (hover) showing the `summary` string and a mini-breakdown table.
+- The data is fetched via `useQuery(['deckPowerLevel', deckId])` — same query key as the tile badge, so TanStack Query's cache ensures a single network request when both tile and modal are visible.
+
+The power level section renders as a loading skeleton while the query is in-flight, and is omitted gracefully on error.
+
+---
+
+## Caching Strategy
+
+No database columns are added. The in-process cache in `power_level_service.py` lives in the backend process memory.
+
+**Cache key**: `(deck_id, user_id, card_count, updated_at_iso_string)`
+
+**Why `user_id` in the key**: The `decks` table is user-scoped, but the cache is process-wide. Including `user_id` prevents a theoretical collision if two users happen to share the same `deck_id` across different PostgreSQL schemas (though the current schema uses a single shared table with `user_id` column — this is a safety measure, not a real risk).
+
+**TTL**: 5 minutes. Short enough that a user who modifies their deck and re-opens the detail view gets a fresh score within a typical session. Long enough to absorb rapid navigation between tiles.
+
+**Invalidation on mutation**: The cache key incorporates `card_count` and `updated_at`. After any `add_card`, `remove_card`, `add_cards_batch`, or `import` operation, the deck's `updated_at` changes (the `update_name` route already sets `updated_at = NOW()`). However, `add_card` and `remove_card` do NOT currently update `decks.updated_at`. A migration or explicit update should be added so the cache key reflects card mutations.
+
+**Fallback**: If the cache lookup encounters a stale key, it recomputes. The entire algorithm runs in O(n) over the card list and completes in microseconds for 100 cards — there is no meaningful performance risk in a cache miss.
+
+---
+
+## Migration Requirements
+
+None required for the core feature. The scoring algorithm uses only existing `cards` columns (`name`, `description`/oracle_text, `type`, `cmc`, `edhrec_rank`).
+
+**Recommended follow-up migration** (not in scope for this change, flagged as a task): Add a `CASCADE UPDATE updated_at` trigger on the `deck_cards` table so that any INSERT/DELETE to `deck_cards` propagates an `updated_at` bump to the parent `decks` row. This makes the cache invalidation strategy bullet-proof.

--- a/openspec/changes/archive/2026-03-16-deck-power-level-estimation/proposal.md
+++ b/openspec/changes/archive/2026-03-16-deck-power-level-estimation/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: Bracket / Power Level Auto-Estimation
+
+**Issue**: #133
+**Status**: Proposed
+**Capability**: Decks / Deck Builder UI
+
+---
+
+## Problem Statement
+
+Commander players need to communicate their deck's power level to their playgroup before sitting down. Today, DeckDex stores the full card composition of a deck but produces no analysis of how powerful that composition is. Players must self-assess — a notoriously unreliable and socially fraught process.
+
+The Commander community uses the Commander Brackets framework (1–4 scale) and informal 1–10 numeric ratings as common vocabulary. DeckDex is well-positioned to automate a first-cut estimate: every card's `oracle_text`, `keywords`, `type_line`, `cmc`, and `mana_cost` are already stored in the `cards` table from Scryfall ingestion.
+
+---
+
+## Proposed Solution
+
+Add a heuristic power-level analysis service that operates entirely on data already in the database. The service evaluates a deck's card list against a curated set of weighted signals — fast mana, tutors, combo density, average CMC, land quality — to produce:
+
+- A numeric score on a 1–10 scale
+- A Commander Bracket classification (1–4) derived from the score
+- A one-sentence natural-language summary (e.g. "7 — strong tempo deck with premium mana base but few tutors")
+- A per-factor breakdown so the user can understand the score
+
+The score is surfaced in two places:
+1. A compact badge on each deck tile in the DeckBuilder grid
+2. A "Power Level" section in the DeckDetailModal header row
+
+---
+
+## User Story
+
+As an MTG Player, I want DeckDex to estimate my deck's power level on the Commander Brackets scale automatically so that I can match my deck to the right playgroup and communicate power level clearly.
+
+---
+
+## Goals
+
+- Estimate power level without any external API calls (fully offline from Scryfall's perspective)
+- Return results in < 200 ms for a typical 100-card Commander deck (all data is local)
+- Display score in both the deck grid tile and the deck detail modal
+- Be explainable: show per-factor breakdown so players can understand and challenge the estimate
+
+## Non-Goals
+
+- Replacing human judgment — this is an aid, not an authority
+- Detecting every combo in existence (the heuristic focuses on well-known signals)
+- Providing different algorithms for different formats (this is Commander/EDH only for now)
+- Persisting the score to the database (computed on demand, see caching strategy in design doc)
+
+---
+
+## Alternatives Considered
+
+1. **OpenAI enrichment**: Rich but slow, costs money, and requires the optional OpenAI integration. Ruled out — this feature should work in the base configuration.
+2. **EDHREC rank thresholds**: EDHREC rank is already stored in `cards.edhrec_rank`. Appealing but unreliable alone: a card with rank 500 could be a staple in the 99 or a commander answer. Kept as a supplemental signal rather than primary.
+3. **Persistent cached score column in `decks` table**: Clean, but requires a migration and invalidation logic. Since computation is fast (< 200 ms), we cache in-process with a short TTL instead. Revisit if profiling shows a bottleneck.

--- a/openspec/changes/archive/2026-03-16-deck-power-level-estimation/tasks.md
+++ b/openspec/changes/archive/2026-03-16-deck-power-level-estimation/tasks.md
@@ -1,0 +1,359 @@
+# Implementation Tasks: Deck Power Level Auto-Estimation
+
+Tasks are ordered by dependency. All backend tasks must be complete before frontend integration tasks.
+
+---
+
+## Task 1 [core] — Implement pure scoring engine
+
+**File**: `deckdex/services/power_level.py` (new file)
+
+**Description**: Create the `estimate_power_level(cards: list[dict]) -> PowerLevelResult` function and its supporting data (curated card sets, bracket mapping, summary builder). This module has zero I/O — it receives a pre-loaded list and returns a result.
+
+**Implement**:
+- `FAST_MANA`, `COMBO_PIECES` frozen sets (lowercase card names)
+- `PREMIUM_LANDS` frozen set (ten original duals, ten shocklands, ten fetchlands, Zendikar battle lands)
+- `FactorBreakdown` Pydantic model (six float fields, all 0.0–1.0)
+- `PowerLevelResult` Pydantic model (`score: float`, `bracket: int`, `summary: str`, `breakdown: FactorBreakdown`)
+- Signal scoring functions for each of the six factors (see design.md for formulas)
+- `_compute_bracket(score: float) -> int` using score threshold table
+- `_build_summary(score: float, breakdown: FactorBreakdown) -> str` — template-based one-sentence summary
+- `estimate_power_level(cards: list[dict]) -> PowerLevelResult` — public entry point
+
+**Field name note**: card dicts use `"description"` for oracle text and `"type"` for type line (matching `_row_to_card` output in `repository.py`). Do not expect `"oracle_text"` or `"type_line"`.
+
+**Acceptance criteria**:
+- A 100-card list with Sol Ring, Mana Crypt, Demonic Tutor, Vampiric Tutor, and 5 fetchlands produces a score >= 6.0
+- An empty list returns score=1.0, bracket=1
+- A list of 99 basic lands + 1 Commander produces score <= 3.0
+- `estimate_power_level` is callable with no network access (unit-testable in isolation)
+
+---
+
+## Task 2 [core] — Write unit tests for scoring engine
+
+**File**: `tests/test_power_level.py` (new file)
+
+**Description**: Pytest unit tests covering the scoring engine. All fixtures use `scope="function"`.
+
+**Test cases**:
+- Empty deck → score=1.0, bracket=1
+- Deck with 4 fast mana cards only → fast_mana breakdown >= 1.0, score elevated
+- Deck with 5 tutor cards only → tutors breakdown = 1.0
+- Deck with known combo pieces (Thassa's Oracle + Demonic Consultation) → combo_pieces > 0
+- Low avg CMC deck (all CMC 1–2 spells) → cmc score high
+- High avg CMC deck (all CMC 5+) → cmc score low
+- Full premium mana base (10 fetchlands) → land_quality = 1.0
+- `_compute_bracket`: verify all boundary values (score 3.0→1, 4.0→2, 6.0→3, 8.0→4)
+- `_build_summary`: returns a non-empty string for any valid breakdown
+- Integration: a representative cEDH-style input (fast mana + tutors + combos) produces score >= 8.0
+
+**Acceptance criteria**:
+- All tests pass with `pytest tests/test_power_level.py`
+- No external I/O, no database connections, no HTTP calls in any test
+
+---
+
+## Task 3 [backend] — Implement backend service (caching layer)
+
+**File**: `backend/api/services/power_level_service.py` (new file)
+
+**Description**: Thin service that wraps `estimate_power_level` with an in-process cache.
+
+**Implement**:
+- Module-level `_cache: dict[tuple, tuple[PowerLevelResult, datetime]]` and `_CACHE_TTL_SECONDS = 300`
+- Cache key: `(deck_id, user_id, card_count, updated_at_str)` where `card_count` is `len(deck["cards"])` and `updated_at_str` is `deck.get("updated_at", "")`.
+- `get_power_level(deck_id: int, repo: DeckRepository, user_id: int) -> PowerLevelResult | None`
+  1. Call `repo.get_deck_with_cards(deck_id, user_id=user_id)`; return `None` if deck is `None`
+  2. Build cache key from result
+  3. Return cached result if present and not expired
+  4. Otherwise call `estimate_power_level(deck["cards"])`, store in cache, return result
+
+**Acceptance criteria**:
+- Two consecutive calls with the same deck (unchanged) produce exactly one call to `estimate_power_level` (cache hit on second call)
+- A deck with a changed `updated_at` value produces a cache miss
+- Returns `None` when deck is not found
+
+---
+
+## Task 4 [backend] — Add API endpoint
+
+**File**: `backend/api/routes/decks.py`
+
+**Description**: Register the new endpoint on the existing `router`.
+
+**Add**:
+```python
+class PowerLevelBreakdownResponse(BaseModel):
+    fast_mana: float
+    tutors: float
+    combo_pieces: float
+    avg_cmc: float
+    land_quality: float
+    staple_density: float
+
+class PowerLevelResponse(BaseModel):
+    score: float
+    bracket: int
+    summary: str
+    breakdown: PowerLevelBreakdownResponse
+```
+
+```python
+@router.get("/{deck_id}/power-level", response_model=PowerLevelResponse)
+async def get_deck_power_level(
+    deck_id: int,
+    repo: DeckRepository = Depends(require_deck_repo),
+    user_id: int = Depends(get_current_user_id),
+):
+    """Return heuristic power level score and Commander Bracket for a deck."""
+    from ..services.power_level_service import get_power_level
+    result = get_power_level(deck_id, repo, user_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Deck not found")
+    return result
+```
+
+**Note**: Import `get_power_level` inside the function body to keep the module-level import surface clean and consistent with the existing pattern in this codebase.
+
+**Acceptance criteria**:
+- `GET /api/decks/1/power-level` returns 200 with the correct JSON structure for an existing deck
+- `GET /api/decks/9999/power-level` returns 404
+- Endpoint appears in the OpenAPI docs at `/docs`
+- Pydantic validation errors in request path params return 400 (handled by existing `validation_exception_handler`)
+
+---
+
+## Task 5 [backend] — Write API endpoint tests
+
+**File**: `tests/test_deck_power_level_api.py` (new file)
+
+**Description**: Integration-style tests for the endpoint using a mocked `DeckRepository`.
+
+All fixtures use `scope="function"`.
+
+**Test cases**:
+- 200 response with valid score/bracket/summary/breakdown shape when deck exists
+- 404 when `get_power_level` returns None (deck not found)
+- Response score is within [1.0, 10.0]
+- Response bracket is within {1, 2, 3, 4}
+- 501 when no Postgres repo (mock `require_deck_repo` to raise HTTPException 501)
+
+**Acceptance criteria**:
+- All tests pass with `pytest tests/test_deck_power_level_api.py`
+- No real database connections; `DeckRepository` is mocked
+
+---
+
+## Task 6 [frontend] — Add API types and client method
+
+**File**: `frontend/src/api/client.ts`
+
+**Description**: Add the TypeScript interface and API function.
+
+**Add interfaces** (after `BatchAddResult`):
+```typescript
+export interface PowerLevelBreakdown {
+  fast_mana: number;
+  tutors: number;
+  combo_pieces: number;
+  avg_cmc: number;
+  land_quality: number;
+  staple_density: number;
+}
+
+export interface PowerLevelResponse {
+  score: number;
+  bracket: number;
+  summary: string;
+  breakdown: PowerLevelBreakdown;
+}
+```
+
+**Add to `api` object** (after `importDeckText`):
+```typescript
+getDeckPowerLevel: async (deckId: number): Promise<PowerLevelResponse> => {
+  const response = await apiFetch(`${API_BASE}/decks/${deckId}/power-level`);
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    if (response.status === 404) throw new Error('Deck not found');
+    if (response.status === 501) throw new Error((err as { detail?: string }).detail || 'Decks require Postgres');
+    throw new Error((err as { detail?: string }).detail || 'Failed to fetch power level');
+  }
+  return response.json();
+},
+```
+
+**Acceptance criteria**:
+- TypeScript compiles without errors (`npm run build`)
+- `api.getDeckPowerLevel` is callable with a number argument and resolves to `PowerLevelResponse`
+
+---
+
+## Task 7 [frontend] — Power level badge on DeckCardButton
+
+**File**: `frontend/src/pages/DeckBuilder.tsx`
+
+**Description**: Add a lazy-loaded power level badge to each `DeckCardButton`.
+
+**Changes inside `DeckCardButton`**:
+1. Add `useQuery` call:
+   ```typescript
+   const { data: powerLevel } = useQuery({
+     queryKey: ['deckPowerLevel', deck.id],
+     queryFn: () => api.getDeckPowerLevel(deck.id),
+     retry: false,
+     staleTime: 5 * 60 * 1000,  // 5 min, matching backend cache TTL
+   });
+   ```
+2. Add bracket-to-colour helper (inline const or small function):
+   ```typescript
+   const BRACKET_COLORS = ['', 'bg-green-600', 'bg-blue-600', 'bg-orange-500', 'bg-red-600'];
+   ```
+3. Render badge (absolute position, bottom-right, only when `powerLevel` is defined):
+   ```tsx
+   {powerLevel && (
+     <span
+       className={`absolute bottom-2 right-2 z-20 text-white text-xs font-semibold px-1.5 py-0.5 rounded ${BRACKET_COLORS[powerLevel.bracket]}`}
+       title={powerLevel.summary}
+     >
+       B{powerLevel.bracket} · {powerLevel.score.toFixed(1)}
+     </span>
+   )}
+   ```
+
+**Acceptance criteria**:
+- Badge visible on deck tiles when power level loads
+- Badge absent (no spinner, no error text) when loading or on error
+- `title` attribute shows the summary string (native browser tooltip)
+- No TypeScript errors
+- Existing snapshot tests still pass (badge is conditionally rendered, test mock returns undefined by default)
+
+---
+
+## Task 8 [frontend] — Power level section in DeckDetailModal
+
+**File**: `frontend/src/components/DeckDetailModal.tsx`
+
+**Description**: Add a power level display to the modal header area.
+
+**Changes**:
+1. Add `useQuery` for power level (same query key as Task 7 — cache deduplication):
+   ```typescript
+   const { data: powerLevel } = useQuery({
+     queryKey: ['deckPowerLevel', deckId],
+     queryFn: () => api.getDeckPowerLevel(deckId),
+     retry: false,
+     staleTime: 5 * 60 * 1000,
+   });
+   ```
+2. Add `BRACKET_LABELS` map:
+   ```typescript
+   const BRACKET_LABELS: Record<number, string> = {
+     1: 'Casual',
+     2: 'Mid Power',
+     3: 'High Power',
+     4: 'Optimised',
+   };
+   ```
+3. Render the power level section in the header row (between mana curve and action buttons), only when `powerLevel` is defined:
+   ```tsx
+   {powerLevel && (
+     <div
+       className="relative group flex flex-col items-center shrink-0 cursor-help"
+       title={powerLevel.summary}
+     >
+       <span className={`text-lg font-bold ${bracketTextColor(powerLevel.bracket)}`}>
+         {powerLevel.score.toFixed(1)}
+       </span>
+       <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+         {BRACKET_LABELS[powerLevel.bracket]} · B{powerLevel.bracket}
+       </span>
+     </div>
+   )}
+   ```
+4. Add `bracketTextColor` helper (inline):
+   ```typescript
+   const bracketTextColor = (b: number) => {
+     if (b === 1) return 'text-green-500';
+     if (b === 2) return 'text-blue-500';
+     if (b === 3) return 'text-orange-500';
+     return 'text-red-500';
+   };
+   ```
+
+**Acceptance criteria**:
+- Power level score and bracket label appear in the modal header for a deck with cards
+- Colour of score text reflects bracket
+- `title` tooltip shows full summary string
+- Section absent when loading or on error (no visible placeholder)
+- Existing `DeckDetailModal.test.tsx` tests still pass
+- No TypeScript errors
+
+---
+
+## Task 9 [frontend] — Add i18n keys
+
+**File**: `frontend/src/locales/en.json`, `frontend/src/locales/es.json`
+
+**Description**: Add localisation keys for the power level feature.
+
+**Keys to add under a new `powerLevel` namespace**:
+```json
+"powerLevel": {
+  "badge": "B{{bracket}} · {{score}}",
+  "casual": "Casual",
+  "midPower": "Mid Power",
+  "highPower": "High Power",
+  "optimised": "Optimised",
+  "bracket": "Bracket {{bracket}}",
+  "loading": "Calculating..."
+}
+```
+
+Add equivalent Spanish translations in `es.json`.
+
+**Note**: Tasks 7 and 8 initially use hardcoded English strings for simplicity. This task upgrades them to use `useTranslation()`. If implementing in a single pass, use `t('powerLevel.casual')` etc. directly.
+
+**Acceptance criteria**:
+- Both `en.json` and `es.json` contain the `powerLevel` namespace
+- No missing key warnings in browser console when navigating to DeckBuilder page
+
+---
+
+## Task 10 [backend] — Trigger updated_at bump on deck_cards mutations (recommended)
+
+**File**: `deckdex/storage/deck_repository.py`
+
+**Description**: After any `add_card`, `remove_card`, `add_cards_batch`, or `import` mutation, explicitly update `decks.updated_at` for the affected deck. This makes the service-layer cache key reliably reflect the true card composition.
+
+**Change pattern** (add at end of each mutating transaction, before `conn.commit()`):
+```python
+conn.execute(
+    text("UPDATE decks SET updated_at = NOW() AT TIME ZONE 'utc' WHERE id = :deck_id"),
+    {"deck_id": deck_id},
+)
+```
+
+**Acceptance criteria**:
+- After `add_card`, `deck.updated_at` changes
+- After `remove_card`, `deck.updated_at` changes
+- Existing deck mutation tests still pass
+
+---
+
+## Dependency Order
+
+```
+Task 1 (scoring engine)
+  └── Task 2 (engine tests)
+  └── Task 3 (service layer)
+        └── Task 4 (API endpoint)
+              └── Task 5 (endpoint tests)
+              └── Task 6 (client types)
+                    └── Task 7 (tile badge)
+                    └── Task 8 (modal section)
+                          └── Task 9 (i18n)
+
+Task 10 (updated_at bump) — independent, can run in parallel with any task
+```

--- a/openspec/changes/archive/2026-03-16-mobile-deck-management/confidence-score.json
+++ b/openspec/changes/archive/2026-03-16-mobile-deck-management/confidence-score.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1",
+  "change": "mobile-deck-management",
+  "agent": "reviewer",
+  "scored_at": "2026-03-16T08:00:00Z",
+  "overall": 85,
+  "aspects": {
+    "type_correctness": 88,
+    "pattern_adherence": 87,
+    "test_coverage": 82,
+    "security": 88,
+    "architectural_alignment": 85
+  },
+  "notes": {
+    "type_correctness": "DeckCardPickerModal correctly types Card import as type-only after fix. Mobile-responsive classes are Tailwind utilities with no type surface.",
+    "pattern_adherence": "import type { Card } was missing — fixed. DeckCardPickerModal follows the AccessibleModal wrapper pattern used across the codebase.",
+    "test_coverage": "DeckCardPickerModal has a smoke test. useSwipeToRemove has 5 unit tests. Touch interaction paths have partial coverage but core render path is verified.",
+    "security": "No new endpoints or data surface introduced by mobile UI changes.",
+    "architectural_alignment": "Modal uses AccessibleModal wrapper pattern. API calls go through api/client.ts addCardsToDeckBatch. Layer boundaries respected."
+  },
+  "flags": []
+}

--- a/openspec/changes/archive/2026-03-16-mobile-deck-management/context-bundle.md
+++ b/openspec/changes/archive/2026-03-16-mobile-deck-management/context-bundle.md
@@ -1,0 +1,343 @@
+# Context Bundle: Mobile-Optimized Deck Management
+
+This file collects the exact code segments and structural facts a developer needs to implement this change without reading the full file on every task.
+
+---
+
+## File inventory
+
+| File | Role | Change type |
+|---|---|---|
+| `frontend/src/components/AccessibleModal.tsx` | Modal wrapper with focus trap | Minor: add `fullScreenOnMobile` prop |
+| `frontend/src/pages/DeckBuilder.tsx` | Deck grid page | Minor: verify tile min-height |
+| `frontend/src/components/DeckDetailModal.tsx` | Main deck modal | Significant: layout, action bar, row styles |
+| `frontend/src/components/DeckCardPickerModal.tsx` | Card picker modal | Minor: full-screen, row height, button width |
+| `frontend/src/components/DeckImportModal.tsx` | Text import modal | Minor: full-screen, textarea flex |
+| `frontend/src/hooks/useSwipeToRemove.ts` | Swipe gesture hook | New file |
+| `frontend/src/locales/en.json` | English strings | Add 4 keys |
+| `frontend/src/locales/es.json` | Spanish strings | Add 4 keys |
+| `frontend/src/hooks/__tests__/useSwipeToRemove.test.ts` | Hook unit tests | New file |
+| `frontend/src/components/__tests__/DeckDetailModal.test.tsx` | Existing test | Add one assertion |
+
+---
+
+## Key existing code segments
+
+### AccessibleModal — current overlay and panel structure
+
+```tsx
+// frontend/src/components/AccessibleModal.tsx  lines 138–164
+return (
+  <div
+    className={`fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 ${className ?? ''}`}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={titleId}
+    onClick={onClose}
+  >
+    <div
+      ref={panelRef}
+      className="relative"
+      onClick={e => e.stopPropagation()}
+    >
+      {showCloseButton && ( ... )}
+      {children}
+    </div>
+  </div>
+);
+```
+
+**What to change:** When `fullScreenOnMobile` is true, replace the overlay's static `flex items-center justify-center p-4` with responsive classes `sm:flex sm:items-center sm:justify-center sm:p-4`, and add `max-sm:w-full max-sm:h-[100dvh]` to the inner panel `div.relative`.
+
+### AccessibleModal — props interface
+
+```tsx
+// lines 5–17
+interface AccessibleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  titleId: string;
+  children: ReactNode;
+  className?: string;
+  showCloseButton?: boolean;
+}
+```
+
+**What to add:** `fullScreenOnMobile?: boolean` (default `false`).
+
+---
+
+### DeckDetailModal — panel div (root of modal content)
+
+```tsx
+// line 266
+<div
+  className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col overflow-hidden"
+>
+```
+
+**What to change:** Add `max-sm:rounded-none max-sm:max-w-none max-sm:max-h-none max-sm:h-full` so on mobile the panel fills the screen. Also pass `fullScreenOnMobile` to the outer `AccessibleModal`.
+
+### DeckDetailModal — left image panel
+
+```tsx
+// line 383
+<div className="w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center justify-start bg-gray-50 dark:bg-gray-900/50 p-4 overflow-visible">
+```
+
+**What to change:** Add `hidden md:flex` to hide on mobile.
+
+### DeckDetailModal — header action buttons row
+
+```tsx
+// line 349
+<div className="flex items-center gap-2 shrink-0 ml-auto">
+  {/* Export, Import, Add card, Delete buttons */}
+</div>
+```
+
+**What to change:** Add `hidden md:flex` so this block is hidden on mobile (replaced by the sticky bar).
+
+### DeckDetailModal — card row `<li>` (current)
+
+```tsx
+// line 430–432
+<li
+  key={card.id}
+  onMouseEnter={() => card.id != null && setHoverCardId(card.id)}
+  onMouseLeave={() => setHoverCardId(null)}
+  className="flex items-center gap-2 py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700/50 group"
+>
+```
+
+**What to change:** `py-1` → `py-2.5`. Add `relative overflow-hidden` for swipe strip positioning. Wrap content in an inner `div` that receives the swipe `transform` style. Extract each `<li>` to a `DeckCardRow` local component to allow per-row hook invocation.
+
+### DeckDetailModal — remove button (current)
+
+```tsx
+// line 459–471
+<button
+  type="button"
+  onClick={(e) => {
+    e.stopPropagation();
+    if (card.id != null) handleRemoveCard(card.id);
+  }}
+  className="opacity-0 group-hover:opacity-100 text-red-600 hover:text-red-700 dark:text-red-400 p-1 rounded flex-shrink-0"
+  aria-label={`Remove ${card.name}`}
+>
+```
+
+**What to change:** Replace `opacity-0 group-hover:opacity-100 ... p-1` with `sm:opacity-0 sm:group-hover:opacity-100 ... p-3 sm:p-1`.
+
+### DeckDetailModal — flex body (main content area below header)
+
+```tsx
+// line 382
+<div className="flex flex-1 overflow-hidden min-h-0">
+```
+
+**What to add:** The mobile sticky action bar is inserted as a child of the outer `flex flex-col` panel, after (not inside) this div. Structure becomes:
+
+```tsx
+<div className="flex flex-col overflow-hidden h-full">
+  {/* header */}
+  <div className="flex flex-1 overflow-hidden min-h-0">
+    {/* image panel - hidden md:flex */}
+    {/* card list */}
+  </div>
+  {/* mobile action bar - md:hidden */}
+  <div className="md:hidden sticky bottom-0 ...">
+    {/* Add, Export, Import, Delete */}
+  </div>
+</div>
+```
+
+---
+
+### DeckCardPickerModal — panel div (current)
+
+```tsx
+// line 98–99
+<div
+  className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col overflow-hidden"
+>
+```
+
+**What to change:** Add `max-sm:rounded-none max-sm:max-w-none max-sm:max-h-none max-sm:h-full max-sm:w-full`. Also pass `fullScreenOnMobile` to `AccessibleModal`.
+
+### DeckCardPickerModal — card list button height (current)
+
+```tsx
+// line 198
+className={`w-full flex items-center gap-2 py-2 px-3 rounded text-left ...`}
+```
+
+**What to change:** `py-2` → `py-3`.
+
+### DeckCardPickerModal — "Add to Deck" footer button (current)
+
+```tsx
+// line 228–234
+<button
+  type="button"
+  onClick={handleAdd}
+  disabled={selected.size === 0 || addPending}
+  className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:hover:bg-indigo-600"
+>
+```
+
+**What to change:** Add `w-full sm:w-auto` to the className.
+
+---
+
+### DeckImportModal — panel div (current)
+
+```tsx
+// line 38–39
+<div
+  className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden"
+>
+```
+
+**What to change:** Add `max-sm:rounded-none max-sm:max-w-none max-sm:h-full`. Pass `fullScreenOnMobile` to `AccessibleModal`.
+
+### DeckImportModal — body div (current)
+
+```tsx
+// line 48
+<div className="px-6 py-4 flex flex-col gap-4">
+```
+
+**What to change:** Add `flex-1` so the body grows to fill available height on full-screen modal.
+
+### DeckImportModal — textarea height (current)
+
+```tsx
+// line 58
+className="w-full h-48 rounded-lg ..."
+```
+
+**What to change:** `h-48` → `sm:h-48 flex-1 min-h-[12rem]` so the textarea fills remaining space on mobile but stays at its current size on desktop.
+
+---
+
+## New file: `useSwipeToRemove` hook
+
+**Location:** `frontend/src/hooks/useSwipeToRemove.ts`
+
+```typescript
+import { useState, useRef, useCallback } from 'react';
+
+const SWIPE_THRESHOLD = 72;
+const AXIS_LOCK_RATIO = 1.5;
+const CAPTURE_START_PX = 8;
+
+export function useSwipeToRemove(onRemove: () => void) {
+  const [translateX, setTranslateX] = useState(0);
+  const [animatingBack, setAnimatingBack] = useState(false);
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const tracking = useRef(false);
+  const axisLocked = useRef<'horizontal' | 'vertical' | null>(null);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse') return;
+    startX.current = e.clientX;
+    startY.current = e.clientY;
+    tracking.current = true;
+    axisLocked.current = null;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!tracking.current) return;
+    const dx = e.clientX - startX.current;
+    const dy = e.clientY - startY.current;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    if (axisLocked.current === null && dist > CAPTURE_START_PX) {
+      axisLocked.current =
+        Math.abs(dx) > Math.abs(dy) * AXIS_LOCK_RATIO ? 'horizontal' : 'vertical';
+    }
+
+    if (axisLocked.current !== 'horizontal') return;
+
+    if (dx < 0) {
+      setAnimatingBack(false);
+      setTranslateX(Math.max(dx, -SWIPE_THRESHOLD));
+    }
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    if (!tracking.current) return;
+    tracking.current = false;
+
+    setTranslateX((prev) => {
+      if (prev <= -SWIPE_THRESHOLD) {
+        onRemove();
+        return 0;
+      }
+      setAnimatingBack(true);
+      setTimeout(() => setAnimatingBack(false), 200);
+      return 0;
+    });
+  }, [onRemove]);
+
+  const onPointerCancel = useCallback(() => {
+    tracking.current = false;
+    setAnimatingBack(true);
+    setTranslateX(0);
+    setTimeout(() => setAnimatingBack(false), 200);
+  }, []);
+
+  return {
+    containerProps: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    translateX,
+    animatingBack,
+    isRevealed: translateX <= -36,
+  };
+}
+```
+
+---
+
+## Locale keys to add
+
+### `en.json` — under `"deckDetail"` object
+
+```json
+"mobileActions": {
+  "addCard": "Add",
+  "export": "Export",
+  "import": "Import",
+  "deleteDeck": "Delete"
+}
+```
+
+### `es.json` — under `"deckDetail"` object
+
+```json
+"mobileActions": {
+  "addCard": "Añadir",
+  "export": "Exportar",
+  "import": "Importar",
+  "deleteDeck": "Eliminar"
+}
+```
+
+---
+
+## Breakpoints reference (Tailwind defaults)
+
+| Prefix | Min width |
+|---|---|
+| `sm:` | 640 px |
+| `md:` | 768 px |
+
+The image panel and desktop header buttons hide at `< md` (768 px). The remove button always-visible behaviour activates at `< sm` (640 px). Full-screen modals via `max-sm:` activate at `< sm` (640 px). These two thresholds are intentionally different: the sticky bar is a layout concern (md), while the remove button visibility is a touch-device concern (sm).
+
+---
+
+## Existing test file to extend
+
+`frontend/src/components/__tests__/DeckDetailModal.test.tsx` — this file already exists. The task requires adding one test; do not modify or remove existing tests.

--- a/openspec/changes/archive/2026-03-16-mobile-deck-management/delta-spec.md
+++ b/openspec/changes/archive/2026-03-16-mobile-deck-management/delta-spec.md
@@ -1,0 +1,108 @@
+# Delta Spec: deck-builder-ui
+
+This file records the changes to `openspec/specs/deck-builder-ui/spec.md` introduced by the mobile-deck-management change. All existing requirements remain valid; the additions below extend them with mobile-specific behaviour.
+
+---
+
+## ADDED Requirement: Touch-optimized tap targets across all deck UI
+
+All interactive elements in the deck builder UI (deck grid tiles, card rows, action buttons, picker rows) SHALL have a minimum touch target size of 44 × 44 px on mobile viewports (viewport width < 768 px). This applies to:
+
+- Deck grid tiles: minimum height 100 px.
+- Card rows in `DeckDetailModal`: minimum row height 44 px.
+- Card rows in `DeckCardPickerModal`: minimum row height 44 px.
+- Action buttons: minimum height 44 px.
+
+### Scenario: Card row is reachable by thumb
+
+- **WHEN** the user views the deck detail modal on a mobile viewport (< 768 px)
+- **THEN** each card row is tall enough to tap reliably without zooming (minimum 44 px height)
+
+---
+
+## ADDED Requirement: Full-screen modals on mobile viewports
+
+The `DeckDetailModal`, `DeckCardPickerModal`, and `DeckImportModal` SHALL each display as full-screen overlays (no overlay padding, panel fills the viewport entirely, no rounded corners) when the viewport width is below 768 px. On viewports 768 px and above, the existing modal layout (max-width, rounded corners, overlay backdrop) is preserved unchanged.
+
+### Scenario: Detail modal fills screen on phone
+
+- **WHEN** the user opens a deck on a viewport narrower than 768 px
+- **THEN** the deck detail modal fills the entire screen with no visible outer overlay padding
+
+### Scenario: Picker modal fills screen on phone
+
+- **WHEN** the user opens the card picker on a viewport narrower than 768 px
+- **THEN** the card picker modal fills the entire screen
+
+---
+
+## ADDED Requirement: Mobile sticky action bar in DeckDetailModal
+
+On viewports narrower than 768 px, the deck detail modal SHALL render a sticky action bar fixed to the bottom of the screen containing the primary actions: Add card, Export, Import, Delete deck. This bar SHALL be hidden on viewports 768 px and above, where the existing header row action buttons are used. Each button in the bar SHALL meet the 44 px minimum height requirement. The Delete button SHALL retain a destructive visual treatment (e.g. red colour). The bar SHALL account for the device safe-area-inset-bottom (notched phones) so the home indicator does not overlap buttons.
+
+### Scenario: Action bar visible on mobile
+
+- **WHEN** the user opens a deck detail modal on a viewport narrower than 768 px
+- **THEN** a sticky bar at the bottom of the screen shows Add card, Export, Import, and Delete deck buttons, each at minimum 44 px tall
+
+### Scenario: Action bar hidden on desktop
+
+- **WHEN** the user opens a deck detail modal on a viewport 768 px or wider
+- **THEN** the sticky action bar is not visible; action buttons appear in the header row as before
+
+---
+
+## ADDED Requirement: Image panel hidden on mobile in DeckDetailModal
+
+On viewports narrower than 768 px, the left image preview panel in the deck detail modal SHALL be hidden to maximise the card list area. The mana curve and total value SHALL remain visible in the header.
+
+### Scenario: Image panel hidden on narrow viewport
+
+- **WHEN** the user opens a deck detail modal on a viewport narrower than 768 px
+- **THEN** the large card image panel is not displayed; the full width is used for the card list
+
+---
+
+## ADDED Requirement: Swipe-to-remove gesture on card rows
+
+On touch/stylus input devices (pointer type is not mouse), swiping a card row in the deck detail modal at least 72 px to the left SHALL trigger a remove action for that card. During the swipe, a red "Remove" affordance SHALL be revealed behind the row. On mouse pointer devices, this gesture is inactive; the existing hover-reveal remove button is used instead.
+
+### Scenario: Swipe removes card on touch device
+
+- **WHEN** the user swipes a card row at least 72 px to the left on a touch device and releases
+- **THEN** the card is removed from the deck (same outcome as clicking the remove button)
+
+### Scenario: Partial swipe snaps back
+
+- **WHEN** the user swipes a card row less than 72 px and releases
+- **THEN** the row returns to its original position and no removal occurs
+
+### Scenario: Swipe does not activate on mouse
+
+- **WHEN** a mouse user interacts with card rows
+- **THEN** swipe-to-remove is inactive; only the existing hover remove button is shown
+
+---
+
+## MODIFIED Requirement: Remove card from deck (existing, extended)
+
+The existing requirement ("the user SHALL be able to remove a card from the deck") is extended as follows:
+
+- On mouse/pointer devices: the per-row remove button is revealed on hover (existing behaviour preserved).
+- On touch devices with viewport < 768 px: the remove button is always visible on each row (not hidden behind `opacity-0 group-hover`), in addition to the swipe-to-remove gesture.
+
+### Scenario: Remove button always visible on mobile
+
+- **WHEN** the user views the deck detail modal on a touch device with viewport < 768 px
+- **THEN** the remove button on each card row is always visible (not dependent on hover state)
+
+---
+
+## ADDED Requirement: DeckCardPickerModal — full-width confirm button on mobile
+
+On viewports narrower than 768 px, the "Add to Deck" confirm button in the card picker footer SHALL be full-width. On wider viewports, the existing right-aligned button width is preserved.
+
+### Scenario: Full-width add button on mobile
+
+- **WHEN** the user views the card picker on a viewport narrower than 768 px
+- **THEN** the "Add to Deck" button spans the full footer width for easy thumb access

--- a/openspec/changes/archive/2026-03-16-mobile-deck-management/design.md
+++ b/openspec/changes/archive/2026-03-16-mobile-deck-management/design.md
@@ -1,0 +1,105 @@
+# Design: Mobile-Optimized Deck Management
+
+## Context
+
+The deck builder UI consists of four components:
+
+1. `DeckBuilder.tsx` — page with the deck grid and `DeckCardButton` tiles.
+2. `DeckDetailModal.tsx` — modal opened per deck; two-column layout (image panel left, card list right); sticky header with action buttons.
+3. `DeckCardPickerModal.tsx` — multi-select card picker opened from the detail modal.
+4. `DeckImportModal.tsx` — text-paste import modal opened from the detail modal.
+
+All four sit inside `AccessibleModal` which wraps a `div.relative` around an arbitrary `children` panel. The overlay is `fixed inset-0 bg-black/50 flex items-center justify-center p-4`. The panel sizing is currently controlled entirely by the `children` themselves (e.g. `max-w-4xl w-full max-h-[90vh]`).
+
+The goal is to make every piece of this flow touch-friendly on small viewports while leaving the desktop path byte-for-byte identical.
+
+## Goals
+
+- Touch targets: every interactive element reachable with a thumb must be at minimum 44 × 44 px (WCAG 2.5.5 AAA / Apple HIG / Material guidelines).
+- Full-screen modals on `< md` (< 768 px): no padding wasted on an overlay backdrop when the viewport itself is small.
+- Persistent remove action on mobile: `opacity-0 group-hover` pattern is mouse-only; on mobile the remove button must be always visible or accessible via swipe.
+- One-handed operation: primary actions (Add, Export, Import, Delete) must be reachable from a bottom action bar on mobile.
+- No new npm dependencies.
+- No backend API changes.
+
+## Non-Goals
+
+- Drag-and-drop reordering of cards within a deck (out of scope for this change).
+- Native mobile app or PWA manifest changes.
+- Swipe-to-navigate between decks.
+
+## Decisions
+
+### 1. Full-screen modal via `AccessibleModal` `fullScreenOnMobile` prop
+
+**Choice:** Add an optional `fullScreenOnMobile?: boolean` prop to `AccessibleModal`. When `true` and the viewport is below the `md` breakpoint, the overlay loses its `p-4 items-center justify-center` centering and the panel gets `w-full h-full rounded-none` so it fills the screen entirely. On `>= md` the component is completely unchanged.
+
+Implementation: use a Tailwind responsive variant approach. The overlay div gets class `sm:p-4 sm:items-center sm:justify-center` (replacing the unconditional ones) and the panel wrapper gets `max-sm:w-full max-sm:h-full max-sm:rounded-none` applied via the `className` prop that callers pass through.
+
+**Why not a separate `FullScreenModal` component:** The accessible behavior (focus trap, scroll lock, Escape key) is already in `AccessibleModal`. Duplicating it would create drift. A single boolean prop is the minimal change.
+
+**Alternatives considered:**
+- CSS-only (no prop change, override via className string): fragile—caller would have to fight the overlay's own `p-4 flex` classes from outside. Rejected.
+- Separate `MobileModal` component: duplication of focus trap logic. Rejected.
+
+### 2. Sticky bottom action bar in `DeckDetailModal` on mobile
+
+**Choice:** On `< md`, the four action buttons (Export, Import, Add card, Delete deck) are moved out of the header row and into a sticky `bottom-0 safe-area-inset-bottom` bar. The bar is rendered as a `div.md:hidden` sibling to the scrollable content area. On `>= md`, the existing header row with `div.hidden md:flex items-center gap-2 ml-auto` is shown. Both coexist in the DOM; Tailwind visibility classes select the correct one per breakpoint.
+
+**Why not a single row that reflows:** On very narrow screens (390 px) the header already contains title, total value, and mana curve. Adding four more buttons causes wrapping. A dedicated bar keeps the header clean and puts primary actions at thumb reach.
+
+**Tap target size:** each bar button gets `flex-1 flex items-center justify-center gap-1 py-3 text-sm font-medium` giving ≥ 44 px height. Delete button retains its red color to preserve the destructive affordance.
+
+### 3. Swipe-to-remove via `useSwipeToRemove` hook
+
+**Choice:** Implement a custom hook `useSwipeToRemove(onRemove: () => void)` that returns `{ containerProps, revealStyle }`. It attaches `onPointerDown` / `onPointerMove` / `onPointerUp` / `onPointerCancel` to the card row `<li>`. When the pointer starts with `pointerType !== 'mouse'` (i.e. touch or stylus), it tracks horizontal delta. At ≥ 72 px leftward swipe the row translates left via a CSS `transform: translateX(${delta}px)` and a red "Remove" strip (`w-[72px] bg-red-500`) slides in from the right edge. On pointer up: if delta ≥ 72 px, call `onRemove()` and reset; else spring back (set `transition: transform 200ms` and reset to 0). On mouse pointer: hook is a no-op (returns empty props and no style).
+
+This avoids any third-party library and uses only the Pointer Events API (universally supported). The hook does not affect keyboard or mouse users at all.
+
+**Why not long-press-to-reveal:** Long-press is often claimed by the browser (context menu on Android Chrome). Horizontal swipe does not conflict with vertical scroll (the hook starts only if `Math.abs(dx) > Math.abs(dy) * 1.5` after the first 8 px of movement to distinguish scroll from swipe).
+
+**Why not always-visible remove button on mobile:** Always showing the remove button shrinks the card name to about 60% of the row width on narrow screens (the row also shows quantity, name, mana cost, and sometimes a "Set as Commander" button). The swipe pattern is standard mobile UX (iOS Mail, most list apps) and preserves full row width for content.
+
+**Alternative: `sm:block` always-visible remove button:** Simpler to implement. However it creates layout pressure on narrow screens and the mana cost icons may be truncated. Retained as a fallback in the risk section.
+
+### 4. Card row tap height
+
+**Choice:** Change `py-1` to `py-2.5` on `<li>` rows in `DeckDetailModal`. This gives each row ~44 px height on a standard 16 px font size (2 × 10 px padding + ~24 px line height = 44 px). This is a global change (desktop and mobile) — it slightly increases list density on desktop but is not visually objectionable.
+
+**Alternative: `max-sm:py-2.5 py-1`:** Would require touch-only overrides. Accepted as fallback; prefer the simpler always-44px approach since the extra 16 px on desktop rows is negligible.
+
+### 5. DeckCardPickerModal card list rows
+
+**Choice:** Change picker list button `py-2` to `py-3` (48 px). The "Add to Deck" footer button gets `w-full sm:w-auto` so it fills the footer on mobile.
+
+### 6. DeckImportModal — full-screen on mobile
+
+**Choice:** Use `fullScreenOnMobile` on the `AccessibleModal`. The textarea inside gets `flex-1` so it expands to fill available height (already in a `flex flex-col` container — just add `flex-1` to the body div).
+
+### 7. Locale keys for bottom action bar
+
+**Choice:** Add four new keys under `deckDetail.mobileActions` in both `en.json` and `es.json`. Use shorter labels than the header buttons to fit in a row of four: "Add", "Export", "Import", "Delete". The existing longer keys (`deckDetail.addCard`, `deckDetail.export`, etc.) remain untouched for the desktop header.
+
+## Component Change Summary
+
+| Component | Mobile change | Desktop change |
+|---|---|---|
+| `AccessibleModal` | New `fullScreenOnMobile` prop removes overlay padding and fills screen | None |
+| `DeckBuilder.tsx` | `min-h-[100px]` on tiles for safe thumb tap | None |
+| `DeckDetailModal.tsx` | Full-screen modal; hide left image panel; sticky bottom bar; swipe-to-remove on rows; always-visible remove on `< md`; increased row tap height | None (header buttons preserved) |
+| `DeckCardPickerModal.tsx` | Full-screen modal; rows `py-3`; "Add" button full-width | None |
+| `DeckImportModal.tsx` | Full-screen modal; textarea `flex-1` | None |
+| `hooks/useSwipeToRemove.ts` | New hook (touch only) | No-op on mouse |
+| `locales/en.json`, `es.json` | Four new `deckDetail.mobileActions.*` keys | Same (shared file) |
+
+## Risks and Mitigations
+
+**Swipe conflicts with scroll:** Mitigated by the axis-lock check in `useSwipeToRemove` — the hook only captures horizontal swipes where `|dx| > |dy| × 1.5`. Vertical scroll is never interrupted.
+
+**Swipe fallback if hook is too complex:** If the swipe UX proves unreliable in QA, replace with always-visible remove button on `< sm` (add `sm:opacity-0 sm:group-hover:opacity-100` to the existing button and `opacity-100` unconditionally on very small screens). The task list calls this out explicitly.
+
+**`safe-area-inset-bottom` for notched phones:** The bottom action bar uses `pb-[env(safe-area-inset-bottom,0px)]` via inline style or a Tailwind plugin to avoid being covered by the home indicator on iPhone. This requires no additional library (CSS env variable is standard).
+
+**`AccessibleModal` panel centering on desktop after prop change:** The responsive class approach (`max-sm:w-full max-sm:h-full`) scopes the full-screen behavior below 640 px — it does not affect `md` (768 px) which is the breakpoint the detail modal uses for its own two-column layout. No overlap.
+
+**Focus management in full-screen modal:** `AccessibleModal` already manages focus trap and Escape-to-close. Full-screen modals use the same mechanism — no change needed.

--- a/openspec/changes/archive/2026-03-16-mobile-deck-management/proposal.md
+++ b/openspec/changes/archive/2026-03-16-mobile-deck-management/proposal.md
@@ -1,0 +1,53 @@
+# Proposal: Mobile-Optimized Deck Management
+
+## Why
+
+MTG players use DeckDex at the LGS (local game store) — away from a laptop, one hand holding cards and one holding a phone. The existing deck builder was designed for desktop: hover-to-preview requires a mouse, the remove button is hidden behind `opacity-0 group-hover:opacity-100`, action buttons are small (`px-3 py-1.5`), and the DeckDetailModal caps at `max-w-4xl` with a rigid two-column layout that collapses poorly below 640 px. The DeckCardPickerModal is fixed at `max-w-2xl max-h-[80vh]` — tolerable on a tablet, cramped on a 390 px phone screen.
+
+This change makes deck editing fully usable on a mobile device without a backend API change, without introducing new dependencies, and without breaking the existing desktop experience.
+
+## What Changes
+
+### DeckBuilder page (deck grid)
+
+- Deck grid switches from `grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5` to `grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5` with `min-h-[100px]` on mobile so tiles remain reachable with a thumb. No structural change to `DeckCardButton`; existing commander-image background logic is preserved.
+
+### DeckDetailModal — responsive two-phase layout
+
+- On mobile (`< md`): modal becomes full-screen (`w-full h-full rounded-none`). The left image panel is hidden; the mana curve and image preview are instead surfaced in a compact top-strip. Action buttons (Export, Import, Add card, Delete) move to a sticky bottom action bar with large tap targets (min 44 px height).
+- On desktop (`>= md`): current layout preserved exactly.
+- The per-row remove button changes from `opacity-0 group-hover:opacity-100` to always visible on mobile (`sm:opacity-0 sm:group-hover:opacity-100`), sized 44 × 44 px minimum via `p-3`.
+- Card rows grow in tap target height on mobile: `py-2.5` instead of `py-1`, giving each row at least 44 px touch area.
+
+### DeckCardPickerModal — full-screen on mobile
+
+- On mobile: modal fills the viewport (`w-full h-full inset-0 rounded-none`); filters collapse into a scrollable row.
+- On desktop: current `max-w-2xl max-h-[80vh]` preserved.
+- Card list rows grow to minimum 44 px tap height (`py-3`).
+- The "Add to Deck" confirm button in the footer grows to full-width on mobile.
+
+### DeckImportModal — full-screen on mobile
+
+- On mobile: modal fills the viewport; textarea grows to fill available space.
+- On desktop: current `max-w-lg` preserved.
+
+### Swipe-to-remove on card rows
+
+- A new hook `useSwipeToRemove` implements horizontal pointer/touch tracking on a card row: swipe left ≥ 72 px reveals a red "Remove" strip behind the row; releasing at that threshold triggers the remove action. On desktop (pointer: fine), the hook is a no-op — the existing hover remove button is used instead.
+- The hook is attached only in `DeckDetailModal` card rows. It does not affect `DeckCardPickerModal`.
+
+### i18n
+
+- Add keys for the mobile action bar labels: `deckDetail.mobileActions.addCard`, `deckDetail.mobileActions.export`, `deckDetail.mobileActions.import`, `deckDetail.mobileActions.deleteDeck`. These are separate from existing header keys so the mobile bar can use shorter text if needed (e.g. "Add", "Export").
+
+## Capabilities Touched
+
+- **deck-builder-ui** (modified): responsive layout requirements for DeckDetailModal, DeckCardPickerModal, DeckImportModal, card row tap targets, swipe-to-remove.
+- **web-dashboard-ui** (advisory): no structural change; Tailwind breakpoint additions are additive.
+- No backend capabilities affected.
+
+## Impact
+
+- **Frontend only**: changes are confined to `DeckBuilder.tsx`, `DeckDetailModal.tsx`, `DeckCardPickerModal.tsx`, `DeckImportModal.tsx`, and `AccessibleModal.tsx` (minor tweak to allow full-screen panel variant). A new hook file `hooks/useSwipeToRemove.ts` is added. Locale files `en.json` and `es.json` receive new keys.
+- **No API changes**: all mutations already go through `api/client.ts`; no new endpoints needed.
+- **No new dependencies**: swipe detection uses the Pointer Events API (already supported in all target browsers).

--- a/openspec/changes/archive/2026-03-16-mobile-deck-management/tasks.md
+++ b/openspec/changes/archive/2026-03-16-mobile-deck-management/tasks.md
@@ -1,0 +1,307 @@
+# Tasks: Mobile-Optimized Deck Management
+
+All tasks are tagged `[frontend]`. No backend tasks.
+
+Dependencies are noted per task. Execute in the order listed; tasks within the same group can be parallelized unless they edit the same file.
+
+---
+
+## Group 1 — Foundation: AccessibleModal full-screen prop
+
+### Task 1.1 — Add `fullScreenOnMobile` prop to `AccessibleModal` [frontend]
+
+**File:** `frontend/src/components/AccessibleModal.tsx`
+
+**Change:** Add optional prop `fullScreenOnMobile?: boolean` to the `AccessibleModalProps` interface. When `true`, replace the overlay's static `p-4 flex items-center justify-center` with responsive Tailwind classes that apply padding and centering only at `sm:` and above, and add `max-sm:w-screen max-sm:h-[100dvh] max-sm:!rounded-none` to the panel's inner wrapper (pass via a `panelClassName` mechanism or apply directly as extra classes on the inner `div.relative`).
+
+Implementation approach: the overlay `div` changes from:
+```
+fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4
+```
+to (when `fullScreenOnMobile` is true):
+```
+fixed inset-0 bg-black/50 sm:flex sm:items-center sm:justify-center z-50 sm:p-4
+```
+The panel wrapper `div.relative` gains `max-sm:w-full max-sm:h-[100dvh]` so it fills the screen on small viewports. No change when `fullScreenOnMobile` is false/absent.
+
+**Acceptance criteria:**
+- Existing modal tests pass without modification (prop defaults to `false`).
+- When `fullScreenOnMobile={true}`, on a viewport narrower than 640 px the panel fills the screen (no visible outer padding).
+- On viewport >= 640 px, behaviour is identical to today regardless of the prop value.
+
+**Dependencies:** None.
+
+---
+
+## Group 2 — Deck grid tile min-height
+
+### Task 2.1 — Ensure deck tiles are thumb-reachable on mobile [frontend]
+
+**File:** `frontend/src/pages/DeckBuilder.tsx`
+
+**Change:** On `DeckCardButton`, change `min-h-[120px]` to `min-h-[100px]` and verify the grid already uses `grid-cols-2` at the smallest breakpoint. No structural change; this is already the case — verify and confirm. Also ensure the "+" add deck tile has the same minimum height.
+
+Note: the current `min-h-[120px]` already exceeds the 44 px requirement. This task is a verification/confirmation step. If any `min-h-[]` is less than 44 px, raise it. If everything is fine, mark as done with a code comment confirming intentional sizes.
+
+**Acceptance criteria:**
+- Both `DeckCardButton` and the "+" tile have min-height >= 44 px.
+- No visual regression on desktop.
+
+**Dependencies:** None (can be done in parallel with Group 1).
+
+---
+
+## Group 3 — DeckDetailModal mobile layout
+
+### Task 3.1 — Apply full-screen modal on mobile in DeckDetailModal [frontend]
+
+**File:** `frontend/src/components/DeckDetailModal.tsx`
+
+**Change:** Pass `fullScreenOnMobile` to the outer `AccessibleModal`. Add `max-sm:rounded-none max-sm:w-full max-sm:h-full` to the panel div (the `bg-white dark:bg-gray-800 rounded-xl` div). Ensure the panel uses `flex flex-col` and `overflow-hidden` already (it does).
+
+**Acceptance criteria:**
+- On viewport < 640 px, the deck detail modal fills the full screen.
+- On viewport >= 768 px, the modal renders identically to today.
+
+**Dependencies:** Task 1.1 must be complete.
+
+### Task 3.2 — Hide left image panel on mobile [frontend]
+
+**File:** `frontend/src/components/DeckDetailModal.tsx`
+
+**Change:** Add `hidden md:flex` (or `hidden md:block`) to the left image panel div (`w-64 flex-shrink-0 border-r ...`). The right card list panel already uses `flex-1 overflow-y-auto` and will expand to full width when the image panel is hidden.
+
+**Acceptance criteria:**
+- On viewport < 768 px, the image panel is not rendered and the card list occupies full modal width.
+- On viewport >= 768 px, the image panel is visible as before.
+
+**Dependencies:** Task 3.1.
+
+### Task 3.3 — Increase card row tap height [frontend]
+
+**File:** `frontend/src/components/DeckDetailModal.tsx`
+
+**Change:** In the `<li>` for each card row, change `py-1` to `py-2.5`. This raises each row to ~44 px. This applies globally (desktop and mobile).
+
+**Acceptance criteria:**
+- Card rows in the modal are visually taller; no content is clipped.
+- Total deck height with 60-card Commander deck still scrolls correctly.
+
+**Dependencies:** Task 3.1 (same file; do together).
+
+### Task 3.4 — Make remove button always visible on touch mobile [frontend]
+
+**File:** `frontend/src/components/DeckDetailModal.tsx`
+
+**Change:** On the remove `<button>` inside each card row, replace:
+```
+className="opacity-0 group-hover:opacity-100 ..."
+```
+with:
+```
+className="sm:opacity-0 sm:group-hover:opacity-100 ..."
+```
+This makes the button always visible on viewports below the `sm` breakpoint (< 640 px), while preserving the hover-only behaviour on desktop.
+
+Also increase the button's touch target: add `p-3` (replacing `p-1`) so the tap area is 44 × 44 px. This slightly increases the button's visual size on desktop as well; adjust to `sm:p-1 p-3` if that is objectionable.
+
+**Acceptance criteria:**
+- On viewport < 640 px, the remove button is always visible on every card row.
+- On viewport >= 640 px (sm and up), the remove button is hidden until the row is hovered.
+- Clicking/tapping the remove button removes the card as before.
+
+**Dependencies:** Task 3.3 (same file; do together).
+
+### Task 3.5 — Add sticky mobile action bar [frontend]
+
+**File:** `frontend/src/components/DeckDetailModal.tsx`
+
+**Change:** Add a `<div className="md:hidden sticky bottom-0 ...">` bar as a sibling to the scrollable card list area (inside the `flex flex-col` modal). The bar contains four buttons: Add card, Export, Import, Delete deck. Wire each to the same handlers as the header buttons: `setPickerOpen(true)`, `handleExport`, `setImportOpen(true)`, `handleDelete`. Apply `pb-[env(safe-area-inset-bottom,0px)]` (inline style: `{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }`) for notch-safe layout.
+
+Each button: `flex-1 flex items-center justify-center gap-1 py-3 text-sm font-medium`. Delete button: `text-red-600 dark:text-red-400`. Add card button: `text-indigo-600 dark:text-indigo-400`. Export and Import: `text-gray-700 dark:text-gray-200`.
+
+Also hide the header action buttons row on mobile: add `hidden md:flex` to the `<div className="flex items-center gap-2 shrink-0 ml-auto">` that currently wraps Export, Import, Add card, Delete.
+
+Use the i18n keys `deckDetail.mobileActions.addCard`, `deckDetail.mobileActions.export`, `deckDetail.mobileActions.import`, `deckDetail.mobileActions.deleteDeck` for the bar labels.
+
+**Acceptance criteria:**
+- On viewport < 768 px, the sticky bar is visible at the bottom of the modal with all four actions.
+- On viewport >= 768 px, the bar is hidden and the header actions are visible.
+- Tapping each bar button triggers the correct action.
+- The bar does not overlap content on notched phones (safe-area padding).
+
+**Dependencies:** Tasks 3.1, 3.2, locale keys from Task 6.1.
+
+---
+
+## Group 4 — Swipe-to-remove hook
+
+### Task 4.1 — Create `useSwipeToRemove` hook [frontend]
+
+**File:** `frontend/src/hooks/useSwipeToRemove.ts` (new file)
+
+**Interface:**
+```typescript
+export function useSwipeToRemove(
+  onRemove: () => void
+): {
+  containerProps: React.HTMLAttributes<HTMLElement>;
+  translateX: number;
+  isRevealed: boolean;
+}
+```
+
+**Behaviour:**
+- On `pointerdown`: if `event.pointerType === 'mouse'`, immediately return (no-op). Otherwise, store `startX`, set `pointerId`, call `element.setPointerCapture(pointerId)`.
+- On `pointermove`: compute `dx = currentX - startX`. If `Math.abs(dx) > Math.abs(dy) * 1.5` and `dx < 0`, set state `translateX = Math.max(dx, -72)` so the row slides left. Emit a CSS variable / state value.
+- On `pointerup` / `pointercancel`: if `translateX <= -72`, call `onRemove()` then reset. Else animate back to 0 (`translateX = 0` with a `transitionDuration` flag set for 200 ms).
+- `containerProps` contains `{ onPointerDown, onPointerMove, onPointerUp, onPointerCancel }`.
+- `translateX` is the current offset in px (0 when idle).
+- `isRevealed` is true when `translateX <= -36` (used to colour the strip red).
+
+**Acceptance criteria:**
+- On a touch device, swiping a row >= 72 px left and releasing calls the `onRemove` callback.
+- Partial swipe (< 72 px) returns the row to position 0 with a short animation.
+- On a mouse device, `containerProps` events are all no-ops (the hook is a no-op branch).
+- Unit test: mock pointer events and assert `onRemove` is called after a ≥ 72 px leftward touch sequence.
+
+**Dependencies:** None.
+
+### Task 4.2 — Wire `useSwipeToRemove` into DeckDetailModal card rows [frontend]
+
+**File:** `frontend/src/components/DeckDetailModal.tsx`
+
+**Change:** Import `useSwipeToRemove`. For each card row `<li>`, extract to a sub-component (or use the hook inline per-item via a wrapper component) that calls `useSwipeToRemove(() => handleRemoveCard(card.id!))`. Apply `containerProps` to the `<li>`. Apply `style={{ transform: \`translateX(\${translateX}px)\`, transition: isAnimatingBack ? 'transform 200ms' : undefined }}` to an inner wrapper div. Behind the row, render an absolutely-positioned `<div className="absolute right-0 inset-y-0 w-[72px] bg-red-500 flex items-center justify-center text-white text-xs font-bold rounded-r">Remove</div>` that is shown when `isRevealed`.
+
+The `<li>` itself needs `relative overflow-hidden` to clip the strip.
+
+Note: since the hook is called per-card, extract the card row to a small local component `DeckCardRow` to allow per-row hook invocation (hooks cannot be called in a loop without a wrapper component).
+
+**Acceptance criteria:**
+- Swiping a card row on a touch device reveals a red strip and removes the card on full swipe.
+- Partial swipe returns to position 0.
+- On desktop (mouse), rows look and behave exactly as before (no red strip, hover remove button works).
+- No regression on existing `DeckDetailModal` tests.
+
+**Dependencies:** Tasks 4.1, 3.1–3.4.
+
+---
+
+## Group 5 — DeckCardPickerModal and DeckImportModal mobile
+
+### Task 5.1 — Make DeckCardPickerModal full-screen on mobile [frontend]
+
+**File:** `frontend/src/components/DeckCardPickerModal.tsx`
+
+**Changes:**
+1. Pass `fullScreenOnMobile` to the `AccessibleModal`.
+2. Add `max-sm:rounded-none max-sm:w-full max-sm:h-full` to the panel div.
+3. Card list buttons: change `py-2` to `py-3`.
+4. Footer "Add to Deck" button: add `w-full sm:w-auto` so it fills the footer row on mobile.
+5. The filters row (`flex flex-wrap items-center gap-3`) already wraps; verify it remains accessible on a 390 px viewport. No structural change needed beyond confirming inputs have sufficient height.
+
+**Acceptance criteria:**
+- On viewport < 640 px, picker fills the screen.
+- On viewport >= 640 px, picker renders with existing `max-w-2xl max-h-[80vh]`.
+- "Add to Deck" is full-width on mobile.
+- Card rows are at least 44 px tall.
+
+**Dependencies:** Task 1.1.
+
+### Task 5.2 — Make DeckImportModal full-screen on mobile [frontend]
+
+**File:** `frontend/src/components/DeckImportModal.tsx`
+
+**Changes:**
+1. Pass `fullScreenOnMobile` to the `AccessibleModal`.
+2. Add `max-sm:rounded-none max-sm:w-full max-sm:h-full max-sm:max-w-none` to the panel div.
+3. Add `flex-1` to the body `<div className="px-6 py-4 flex flex-col gap-4">` so it grows to fill available height.
+4. Add `flex-1` to the `<textarea>` (remove fixed `h-48` on mobile via `sm:h-48 h-auto flex-1`).
+
+**Acceptance criteria:**
+- On viewport < 640 px, import modal fills the screen; textarea expands to fill available space.
+- On viewport >= 640 px, modal renders with existing `max-w-lg`; textarea retains its `h-48`.
+
+**Dependencies:** Task 1.1.
+
+---
+
+## Group 6 — i18n
+
+### Task 6.1 — Add mobile action bar locale keys [frontend]
+
+**Files:** `frontend/src/locales/en.json`, `frontend/src/locales/es.json`
+
+**Change:** Add the following keys nested under `"deckDetail"`:
+
+```json
+"mobileActions": {
+  "addCard": "Add",
+  "export": "Export",
+  "import": "Import",
+  "deleteDeck": "Delete"
+}
+```
+
+Spanish equivalents in `es.json`:
+```json
+"mobileActions": {
+  "addCard": "Añadir",
+  "export": "Exportar",
+  "import": "Importar",
+  "deleteDeck": "Eliminar"
+}
+```
+
+**Acceptance criteria:**
+- Both locale files are valid JSON after the change.
+- Keys are nested correctly under the existing `deckDetail` object.
+- No other existing keys are modified.
+
+**Dependencies:** None.
+
+---
+
+## Group 7 — Tests
+
+### Task 7.1 — Unit test for `useSwipeToRemove` [frontend]
+
+**File:** `frontend/src/hooks/__tests__/useSwipeToRemove.test.ts` (new file)
+
+**Tests:**
+1. Mouse pointerdown → `onRemove` never called, `translateX` stays 0.
+2. Touch pointerdown + pointermove 80 px left + pointerup → `onRemove` called once.
+3. Touch pointerdown + pointermove 40 px left + pointerup → `onRemove` not called, `translateX` returns to 0.
+4. Touch pointerdown + pointermove more horizontal than vertical (passes axis-lock) → captured; opposite (more vertical) → not captured.
+
+Use Vitest + `@testing-library/react` with `renderHook`. Simulate pointer events via `fireEvent` or direct calls to the returned handlers.
+
+**Acceptance criteria:**
+- All four test cases pass.
+- No `scope="module"` fixture issues (pure hook, no fixtures needed).
+
+**Dependencies:** Task 4.1.
+
+### Task 7.2 — DeckDetailModal: verify mobile remove button visibility [frontend]
+
+**File:** `frontend/src/components/__tests__/DeckDetailModal.test.tsx` (existing file)
+
+**Change:** Add one test that renders `DeckDetailModal` and asserts the remove button for a card row does not have `opacity-0` as an unconditional class (i.e. the class is now `sm:opacity-0 sm:group-hover:opacity-100`). This is a snapshot/class-check test, not a visual test.
+
+**Acceptance criteria:**
+- New test passes.
+- No existing tests broken.
+
+**Dependencies:** Task 3.4.
+
+### Task 7.3 — Smoke test: DeckCardPickerModal "Add to Deck" is full-width on mobile [frontend]
+
+**File:** `frontend/src/components/__tests__/DeckCardPickerModal.test.tsx` (new or existing)
+
+If no test file exists, create one. Add a test that renders the picker and asserts the "Add to Deck" button has the class `w-full` in its class list.
+
+**Acceptance criteria:**
+- Test passes.
+- No existing tests broken.
+
+**Dependencies:** Task 5.1.

--- a/tests/test_allocations.py
+++ b/tests/test_allocations.py
@@ -1,0 +1,201 @@
+"""Tests for GET /api/cards/allocations endpoint."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api.dependencies import get_current_user_id
+from backend.api.main import app
+from backend.api.routes.cards import _require_deck_repo_for_allocations
+from deckdex.storage.deck_repository import DeckRepository  # noqa: F401 — used in MagicMock(spec=...)
+
+# ---------------------------------------------------------------------------
+# Fixtures — all scope="function" to prevent cross-test mock pollution
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def auth_client():
+    """TestClient with authenticated user (user_id=1). No deck repo override."""
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.pop(get_current_user_id, None)
+
+
+@pytest.fixture(scope="function")
+def allocation_client():
+    """TestClient with both auth and a mocked DeckRepository.
+
+    Yields (client, mock_repo). Configure mock_repo return values per test.
+    """
+    mock_repo = MagicMock(spec=DeckRepository)
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    app.dependency_overrides[_require_deck_repo_for_allocations] = lambda: mock_repo
+    client = TestClient(app)
+    yield client, mock_repo
+    app.dependency_overrides.pop(get_current_user_id, None)
+    app.dependency_overrides.pop(_require_deck_repo_for_allocations, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_allocations_unauthenticated():
+    """Unauthenticated request returns 401."""
+    client = TestClient(app)
+    response = client.get("/api/cards/allocations")
+    assert response.status_code == 401
+
+
+def test_allocations_no_postgres(auth_client):
+    """Returns 501 when Postgres is not configured (deck repo unavailable)."""
+    # Override: repo guard returns None → 501
+    app.dependency_overrides[_require_deck_repo_for_allocations] = lambda: (_ for _ in ()).throw(
+        __import__("fastapi").HTTPException(status_code=501, detail="Allocations require Postgres.")
+    )
+    try:
+        response = auth_client.get("/api/cards/allocations")
+        assert response.status_code == 501
+    finally:
+        app.dependency_overrides.pop(_require_deck_repo_for_allocations, None)
+
+
+def test_allocations_empty_collection(allocation_client):
+    """Returns empty cards list when user has no cards."""
+    client, mock_repo = allocation_client
+    mock_repo.get_all_card_allocations.return_value = []
+
+    response = client.get("/api/cards/allocations")
+
+    assert response.status_code == 200
+    assert response.json() == {"cards": []}
+
+
+def test_allocations_card_in_no_deck(allocation_client):
+    """Card with deck_id=None appears with empty decks array."""
+    client, mock_repo = allocation_client
+    mock_repo.get_all_card_allocations.return_value = [
+        {
+            "card_id": 1,
+            "card_name": "Lightning Bolt",
+            "image_url": None,
+            "type_line": "Instant",
+            "mana_cost": "{R}",
+            "quantity": 1,
+            "deck_id": None,
+            "deck_name": None,
+        },
+    ]
+
+    response = client.get("/api/cards/allocations")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["cards"]) == 1
+    assert data["cards"][0]["card_name"] == "Lightning Bolt"
+    assert data["cards"][0]["decks"] == []
+
+
+def test_allocations_card_in_one_deck(allocation_client):
+    """Card in one deck has one entry in decks array."""
+    client, mock_repo = allocation_client
+    mock_repo.get_all_card_allocations.return_value = [
+        {
+            "card_id": 2,
+            "card_name": "Sol Ring",
+            "image_url": None,
+            "type_line": "Artifact",
+            "mana_cost": "{1}",
+            "quantity": 1,
+            "deck_id": 10,
+            "deck_name": "My Commander",
+        },
+    ]
+
+    response = client.get("/api/cards/allocations")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["cards"]) == 1
+    assert len(data["cards"][0]["decks"]) == 1
+    assert data["cards"][0]["decks"][0]["deck_id"] == 10
+    assert data["cards"][0]["decks"][0]["deck_name"] == "My Commander"
+
+
+def test_allocations_card_in_multiple_decks(allocation_client):
+    """Card in two decks appears once in response with two entries in decks array."""
+    client, mock_repo = allocation_client
+    mock_repo.get_all_card_allocations.return_value = [
+        {
+            "card_id": 3,
+            "card_name": "Island",
+            "image_url": None,
+            "type_line": "Basic Land",
+            "mana_cost": None,
+            "quantity": 4,
+            "deck_id": 10,
+            "deck_name": "Deck A",
+        },
+        {
+            "card_id": 3,
+            "card_name": "Island",
+            "image_url": None,
+            "type_line": "Basic Land",
+            "mana_cost": None,
+            "quantity": 4,
+            "deck_id": 11,
+            "deck_name": "Deck B",
+        },
+    ]
+
+    response = client.get("/api/cards/allocations")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["cards"]) == 1  # deduplicated by card_id
+    assert len(data["cards"][0]["decks"]) == 2
+    deck_ids = {d["deck_id"] for d in data["cards"][0]["decks"]}
+    assert deck_ids == {10, 11}
+
+
+def test_allocations_multiple_cards(allocation_client):
+    """Multiple cards with mixed deck assignments aggregate correctly."""
+    client, mock_repo = allocation_client
+    mock_repo.get_all_card_allocations.return_value = [
+        # Card 1: in no deck
+        {
+            "card_id": 1,
+            "card_name": "Forest",
+            "image_url": None,
+            "type_line": "Basic Land",
+            "mana_cost": None,
+            "quantity": 10,
+            "deck_id": None,
+            "deck_name": None,
+        },
+        # Card 2: in one deck
+        {
+            "card_id": 2,
+            "card_name": "Sol Ring",
+            "image_url": None,
+            "type_line": "Artifact",
+            "mana_cost": "{1}",
+            "quantity": 1,
+            "deck_id": 5,
+            "deck_name": "Atraxa",
+        },
+    ]
+
+    response = client.get("/api/cards/allocations")
+
+    assert response.status_code == 200
+    data = response.json()
+    cards = {c["card_id"]: c for c in data["cards"]}
+    assert len(cards) == 2
+    assert cards[1]["decks"] == []
+    assert len(cards[2]["decks"]) == 1
+    assert cards[2]["decks"][0]["deck_name"] == "Atraxa"

--- a/tests/test_deck_power_level_api.py
+++ b/tests/test_deck_power_level_api.py
@@ -1,0 +1,227 @@
+"""Integration-style tests for GET /api/decks/{deck_id}/power-level.
+
+All fixtures use scope="function". DeckRepository is mocked — no real DB connections.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from backend.api.dependencies import get_current_user_id
+from backend.api.main import app
+from backend.api.routes.decks import require_deck_repo
+from deckdex.storage.deck_repository import DeckRepository
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_DECK_WITH_CARDS = {
+    "id": 1,
+    "name": "Test Deck",
+    "created_at": "2026-01-01T00:00:00",
+    "updated_at": "2026-01-01T00:00:00",
+    "cards": [
+        {
+            "id": 10,
+            "name": "Sol Ring",
+            "description": "",
+            "type": "Artifact",
+            "cmc": 1.0,
+            "edhrec_rank": 1,
+            "quantity": 1,
+            "is_commander": False,
+        },
+        {
+            "id": 20,
+            "name": "Demonic Tutor",
+            "description": "Search your library for a card",
+            "type": "Sorcery",
+            "cmc": 2.0,
+            "edhrec_rank": 10,
+            "quantity": 1,
+            "is_commander": False,
+        },
+        {
+            "id": 30,
+            "name": "Swamp",
+            "description": "",
+            "type": "Basic Land — Swamp",
+            "cmc": 0.0,
+            "edhrec_rank": 999,
+            "quantity": 30,
+            "is_commander": False,
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def power_level_client():
+    """TestClient with mocked DeckRepository and auth.
+
+    Yields (client, mock_repo). Dependency overrides are cleaned up after each test.
+    """
+    mock_repo = MagicMock(spec=DeckRepository)
+    app.dependency_overrides[require_deck_repo] = lambda: mock_repo
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    client = TestClient(app)
+    yield client, mock_repo
+    app.dependency_overrides.pop(require_deck_repo, None)
+    app.dependency_overrides.pop(get_current_user_id, None)
+
+
+@pytest.fixture(scope="function")
+def no_repo_client():
+    """TestClient where require_deck_repo raises 501 (no Postgres configured)."""
+    app.dependency_overrides[require_deck_repo] = lambda: (_ for _ in ()).throw(
+        HTTPException(status_code=501, detail="Decks require Postgres. Set DATABASE_URL to use the deck builder.")
+    )
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+    app.dependency_overrides.pop(require_deck_repo, None)
+    app.dependency_overrides.pop(get_current_user_id, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: 200 success
+# ---------------------------------------------------------------------------
+
+
+def test_power_level_200_for_existing_deck(power_level_client):
+    """Endpoint returns 200 with correct response shape when deck exists."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = SAMPLE_DECK_WITH_CARDS
+
+    response = client.get("/api/decks/1/power-level")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "score" in data
+    assert "bracket" in data
+    assert "summary" in data
+    assert "breakdown" in data
+    breakdown = data["breakdown"]
+    assert set(breakdown.keys()) == {"fast_mana", "tutors", "combo_pieces", "avg_cmc", "land_quality", "staple_density"}
+
+
+def test_power_level_score_in_valid_range(power_level_client):
+    """Response score is within [1.0, 10.0]."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = SAMPLE_DECK_WITH_CARDS
+
+    response = client.get("/api/decks/1/power-level")
+
+    assert response.status_code == 200
+    score = response.json()["score"]
+    assert 1.0 <= score <= 10.0
+
+
+def test_power_level_bracket_in_valid_range(power_level_client):
+    """Response bracket is within {1, 2, 3, 4}."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = SAMPLE_DECK_WITH_CARDS
+
+    response = client.get("/api/decks/1/power-level")
+
+    assert response.status_code == 200
+    bracket = response.json()["bracket"]
+    assert bracket in {1, 2, 3, 4}
+
+
+def test_power_level_summary_is_non_empty_string(power_level_client):
+    """Summary field is a non-empty string."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = SAMPLE_DECK_WITH_CARDS
+
+    response = client.get("/api/decks/1/power-level")
+
+    assert response.status_code == 200
+    summary = response.json()["summary"]
+    assert isinstance(summary, str)
+    assert len(summary) > 0
+
+
+def test_power_level_breakdown_values_in_range(power_level_client):
+    """All breakdown factor values are in [0.0, 1.0]."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = SAMPLE_DECK_WITH_CARDS
+
+    response = client.get("/api/decks/1/power-level")
+
+    assert response.status_code == 200
+    breakdown = response.json()["breakdown"]
+    for key, value in breakdown.items():
+        assert 0.0 <= value <= 1.0, f"Breakdown factor '{key}' out of range: {value}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: 404 not found
+# ---------------------------------------------------------------------------
+
+
+def test_power_level_404_when_deck_not_found(power_level_client):
+    """Returns 404 when get_power_level returns None (deck not found)."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = None
+
+    response = client.get("/api/decks/9999/power-level")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: 501 no Postgres
+# ---------------------------------------------------------------------------
+
+
+def test_power_level_501_when_no_postgres(no_repo_client):
+    """Returns 501 when require_deck_repo raises HTTPException 501."""
+    response = no_repo_client.get("/api/decks/1/power-level")
+
+    assert response.status_code == 501
+
+
+# ---------------------------------------------------------------------------
+# Tests: caching behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_power_level_cache_hit_single_estimate_call(power_level_client):
+    """Two consecutive calls with unchanged deck produce exactly one estimate_power_level call."""
+    client, mock_repo = power_level_client
+    mock_repo.get_deck_with_cards.return_value = SAMPLE_DECK_WITH_CARDS
+
+    # Clear the module-level cache first to avoid pollution from other tests
+    import backend.api.services.power_level_service as svc
+
+    svc._cache.clear()
+
+    with patch("backend.api.services.power_level_service.estimate_power_level", wraps=None) as mock_est:
+        from deckdex.services.power_level import FactorBreakdown, PowerLevelResult
+
+        mock_est.return_value = PowerLevelResult(
+            score=5.0,
+            bracket=2,
+            summary="5 — mid-power deck",
+            breakdown=FactorBreakdown(
+                fast_mana=0.25,
+                tutors=0.4,
+                combo_pieces=0.0,
+                avg_cmc=0.55,
+                land_quality=0.0,
+                staple_density=0.2,
+            ),
+        )
+        client.get("/api/decks/1/power-level")
+        client.get("/api/decks/1/power-level")
+        assert mock_est.call_count == 1

--- a/tests/test_power_level.py
+++ b/tests/test_power_level.py
@@ -1,0 +1,364 @@
+"""Unit tests for deckdex/services/power_level.py"""
+
+import pytest
+
+from deckdex.services.power_level import (
+    FactorBreakdown,
+    _build_summary,
+    _compute_bracket,
+    estimate_power_level,
+)
+
+
+def _card(
+    name: str,
+    description: str = "",
+    type_: str = "Instant",
+    cmc: float = 2.0,
+    edhrec_rank: int = 999,
+    quantity: int = 1,
+) -> dict:
+    return {
+        "name": name,
+        "description": description,
+        "type": type_,
+        "cmc": cmc,
+        "edhrec_rank": edhrec_rank,
+        "quantity": quantity,
+    }
+
+
+@pytest.fixture()
+def empty_deck():
+    return []
+
+
+@pytest.fixture()
+def fast_mana_deck():
+    return [
+        _card("Sol Ring", cmc=1),
+        _card("Mana Crypt", cmc=0),
+        _card("Mana Vault", cmc=1),
+        _card("Chrome Mox", cmc=0),
+    ]
+
+
+@pytest.fixture()
+def tutor_deck():
+    return [
+        _card("Demonic Tutor", description="Search your library for a card"),
+        _card("Vampiric Tutor", description="Search your library for a card"),
+        _card("Enlightened Tutor", description="Search your library for a card"),
+        _card("Imperial Seal", description="Search your library for a card"),
+        _card("Mystical Tutor", description="Search your library for a card"),
+    ]
+
+
+@pytest.fixture()
+def basic_land_deck():
+    """99 basic lands + 1 plain creature commander."""
+    lands = [_card("Plains", type_="Basic Land — Plains", cmc=0) for _ in range(99)]
+    commander = _card("Isamaru, Hound of Konda", type_="Legendary Creature — Dog", cmc=1)
+    return lands + [commander]
+
+
+@pytest.fixture()
+def cehdh_deck():
+    """Representative cEDH-style input with fast mana, tutors, and combos."""
+    return [
+        _card("Sol Ring", cmc=1),
+        _card("Mana Crypt", cmc=0),
+        _card("Mana Vault", cmc=1),
+        _card("Chrome Mox", cmc=0),
+        _card("Demonic Tutor", description="Search your library for a card", cmc=2),
+        _card("Vampiric Tutor", description="Search your library for a card", cmc=1),
+        _card("Enlightened Tutor", description="Search your library for a card", cmc=1),
+        _card("Imperial Seal", description="Search your library for a card", cmc=1),
+        _card("Mystical Tutor", description="Search your library for a card", cmc=1),
+        _card("Thassa's Oracle", cmc=2),
+        _card("Demonic Consultation", cmc=1),
+        _card("Tainted Pact", cmc=2),
+        _card("Flooded Strand", type_="Land", cmc=0),
+        _card("Polluted Delta", type_="Land", cmc=0),
+        _card("Scalding Tarn", type_="Land", cmc=0),
+        _card("Misty Rainforest", type_="Land", cmc=0),
+        _card("Verdant Catacombs", type_="Land", cmc=0),
+        _card("Bloodstained Mire", type_="Land", cmc=0),
+        _card("Wooded Foothills", type_="Land", cmc=0),
+        _card("Windswept Heath", type_="Land", cmc=0),
+        _card("Marsh Flats", type_="Land", cmc=0),
+        _card("Arid Mesa", type_="Land", cmc=0),
+    ]
+
+
+class TestEmptyDeck:
+    def test_score_is_one(self, empty_deck):
+        result = estimate_power_level(empty_deck)
+        assert result.score == 1.0
+
+    def test_bracket_is_one(self, empty_deck):
+        result = estimate_power_level(empty_deck)
+        assert result.bracket == 1
+
+    def test_summary_mentions_no_cards(self, empty_deck):
+        result = estimate_power_level(empty_deck)
+        assert "1" in result.summary
+
+
+class TestFastMana:
+    def test_four_fast_mana_cards_max_factor(self, fast_mana_deck):
+        result = estimate_power_level(fast_mana_deck)
+        assert result.breakdown.fast_mana == 1.0
+
+    def test_score_elevated(self, fast_mana_deck):
+        result = estimate_power_level(fast_mana_deck)
+        assert result.score >= 4.0
+
+    def test_partial_fast_mana(self):
+        cards = [_card("Sol Ring", cmc=1)]
+        result = estimate_power_level(cards)
+        assert result.breakdown.fast_mana == pytest.approx(0.25)
+
+
+class TestTutors:
+    def test_five_tutors_max_factor(self, tutor_deck):
+        result = estimate_power_level(tutor_deck)
+        assert result.breakdown.tutors == 1.0
+
+    def test_no_tutors_zero_factor(self):
+        cards = [_card("Lightning Bolt")]
+        result = estimate_power_level(cards)
+        assert result.breakdown.tutors == 0.0
+
+    def test_partial_tutors(self):
+        cards = [
+            _card("Demonic Tutor", description="Search your library for a card"),
+            _card("Vampiric Tutor", description="Search your library for a card"),
+        ]
+        result = estimate_power_level(cards)
+        # 2 tutors / 5 = 0.4
+        assert result.breakdown.tutors == pytest.approx(0.4)
+
+
+class TestComboPieces:
+    def test_known_combo_pieces_detected(self):
+        cards = [
+            _card("Thassa's Oracle", cmc=2),
+            _card("Demonic Consultation", cmc=1),
+        ]
+        result = estimate_power_level(cards)
+        assert result.breakdown.combo_pieces > 0.0
+
+    def test_infinite_in_oracle_text_detected(self):
+        cards = [
+            _card("Custom Combo Card", description="Creates infinite tokens"),
+        ]
+        result = estimate_power_level(cards)
+        assert result.breakdown.combo_pieces > 0.0
+
+    def test_three_combo_pieces_max_factor(self):
+        cards = [
+            _card("Thassa's Oracle"),
+            _card("Demonic Consultation"),
+            _card("Tainted Pact"),
+        ]
+        result = estimate_power_level(cards)
+        assert result.breakdown.combo_pieces == 1.0
+
+
+class TestAvgCmc:
+    def test_low_cmc_deck_high_score(self):
+        cards = [_card(f"Spell{i}", cmc=1.0) for i in range(10)]
+        result = estimate_power_level(cards)
+        # avg_cmc <= 1.5 → 1.0
+        assert result.breakdown.avg_cmc == 1.0
+
+    def test_high_cmc_deck_low_score(self):
+        cards = [_card(f"Spell{i}", cmc=6.0) for i in range(10)]
+        result = estimate_power_level(cards)
+        # avg_cmc > 4.0 → 0.10
+        assert result.breakdown.avg_cmc == pytest.approx(0.10)
+
+    def test_cmc_2_0_band(self):
+        cards = [_card(f"Spell{i}", cmc=2.0) for i in range(10)]
+        result = estimate_power_level(cards)
+        # avg_cmc <= 2.0 → 0.85
+        assert result.breakdown.avg_cmc == pytest.approx(0.85)
+
+    def test_lands_excluded_from_avg_cmc(self):
+        # All lands: should return 0.5 (fallback for no non-lands)
+        cards = [_card("Swamp", type_="Basic Land — Swamp", cmc=0.0) for _ in range(5)]
+        result = estimate_power_level(cards)
+        assert result.breakdown.avg_cmc == 0.5
+
+    def test_cmc_weighted_by_quantity(self):
+        # One copy of CMC-1 card (qty=1) and one copy of CMC-3 (qty=1) → avg=2.0 → 0.85
+        cards = [
+            {"name": "A", "description": "", "type": "Instant", "cmc": 1.0, "edhrec_rank": 999, "quantity": 1},
+            {"name": "B", "description": "", "type": "Instant", "cmc": 3.0, "edhrec_rank": 999, "quantity": 1},
+        ]
+        result = estimate_power_level(cards)
+        assert result.breakdown.avg_cmc == pytest.approx(0.85)
+
+
+class TestLandQuality:
+    def test_ten_premium_lands_max_factor(self):
+        lands = [
+            _card("Flooded Strand", type_="Land"),
+            _card("Polluted Delta", type_="Land"),
+            _card("Scalding Tarn", type_="Land"),
+            _card("Misty Rainforest", type_="Land"),
+            _card("Verdant Catacombs", type_="Land"),
+            _card("Bloodstained Mire", type_="Land"),
+            _card("Wooded Foothills", type_="Land"),
+            _card("Windswept Heath", type_="Land"),
+            _card("Marsh Flats", type_="Land"),
+            _card("Arid Mesa", type_="Land"),
+        ]
+        result = estimate_power_level(lands)
+        assert result.breakdown.land_quality == 1.0
+
+    def test_no_premium_lands_zero_factor(self):
+        cards = [_card("Swamp", type_="Basic Land — Swamp") for _ in range(5)]
+        result = estimate_power_level(cards)
+        assert result.breakdown.land_quality == 0.0
+
+    def test_five_fetchlands_half_factor(self):
+        lands = [
+            _card("Flooded Strand", type_="Land"),
+            _card("Polluted Delta", type_="Land"),
+            _card("Scalding Tarn", type_="Land"),
+            _card("Misty Rainforest", type_="Land"),
+            _card("Verdant Catacombs", type_="Land"),
+        ]
+        result = estimate_power_level(lands)
+        assert result.breakdown.land_quality == pytest.approx(0.5)
+
+
+class TestStapleDensity:
+    def test_high_edhrec_rank_not_staple(self):
+        cards = [_card("Obscure Card", edhrec_rank=10000)]
+        result = estimate_power_level(cards)
+        assert result.breakdown.staple_density == 0.0
+
+    def test_low_edhrec_rank_is_staple(self):
+        cards = [_card("Sol Ring", edhrec_rank=1)]
+        result = estimate_power_level(cards)
+        assert result.breakdown.staple_density > 0.0
+
+    def test_none_edhrec_rank_skipped(self):
+        cards = [{"name": "Card", "description": "", "type": "Instant", "cmc": 2.0, "edhrec_rank": None, "quantity": 1}]
+        result = estimate_power_level(cards)
+        assert result.breakdown.staple_density == 0.0
+
+
+class TestComputeBracket:
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (1.0, 1),
+            (3.0, 1),
+            (3.9, 1),
+            (4.0, 2),
+            (5.9, 2),
+            (6.0, 3),
+            (7.9, 3),
+            (8.0, 4),
+            (10.0, 4),
+        ],
+    )
+    def test_bracket_thresholds(self, score, expected):
+        assert _compute_bracket(score) == expected
+
+
+class TestBuildSummary:
+    def test_returns_non_empty_string(self):
+        bd = FactorBreakdown(
+            fast_mana=0.5,
+            tutors=0.2,
+            combo_pieces=0.0,
+            avg_cmc=0.7,
+            land_quality=0.6,
+            staple_density=0.3,
+        )
+        result = _build_summary(6.5, bd)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_score_appears_in_summary(self):
+        bd = FactorBreakdown(
+            fast_mana=0.0,
+            tutors=0.0,
+            combo_pieces=0.0,
+            avg_cmc=0.5,
+            land_quality=0.0,
+            staple_density=0.0,
+        )
+        result = _build_summary(3.0, bd)
+        assert "3" in result
+
+    def test_positives_mentioned_when_high(self):
+        bd = FactorBreakdown(
+            fast_mana=1.0,
+            tutors=1.0,
+            combo_pieces=0.0,
+            avg_cmc=0.3,
+            land_quality=0.0,
+            staple_density=0.0,
+        )
+        result = _build_summary(7.0, bd)
+        assert "fast mana" in result or "tutors" in result
+
+    def test_absence_mentioned_when_zero(self):
+        bd = FactorBreakdown(
+            fast_mana=0.0,
+            tutors=0.0,
+            combo_pieces=0.0,
+            avg_cmc=1.0,
+            land_quality=0.0,
+            staple_density=0.0,
+        )
+        result = _build_summary(2.0, bd)
+        assert "no" in result
+
+
+class TestBasicLandDeck:
+    def test_basic_land_deck_low_score(self, basic_land_deck):
+        result = estimate_power_level(basic_land_deck)
+        assert result.score <= 3.0
+
+
+class TestCEDHDeck:
+    def test_cehdh_style_deck_high_score(self, cehdh_deck):
+        result = estimate_power_level(cehdh_deck)
+        assert result.score >= 8.0
+
+    def test_cehdh_bracket_is_four(self, cehdh_deck):
+        result = estimate_power_level(cehdh_deck)
+        assert result.bracket == 4
+
+
+class TestKnownHighPowerDeck:
+    def test_sol_ring_mana_crypt_tutors_fetchlands_score_above_six(self):
+        """A 100-card list with Sol Ring, Mana Crypt, tutors, 5 fetchlands, and realistic EDHREC ranks produces score >= 6.0."""
+        # Use realistic EDHREC ranks: Sol Ring ~1, Mana Crypt ~2, Demonic Tutor ~5, Vampiric Tutor ~10
+        cards = [
+            _card("Sol Ring", cmc=1, edhrec_rank=1),
+            _card("Mana Crypt", cmc=0, edhrec_rank=2),
+            _card("Mana Vault", cmc=1, edhrec_rank=3),
+            _card("Chrome Mox", cmc=0, edhrec_rank=4),
+            _card("Demonic Tutor", description="Search your library for a card", cmc=2, edhrec_rank=5),
+            _card("Vampiric Tutor", description="Search your library for a card", cmc=1, edhrec_rank=6),
+            _card("Enlightened Tutor", description="Search your library for a card", cmc=1, edhrec_rank=7),
+            _card("Imperial Seal", description="Search your library for a card", cmc=1, edhrec_rank=8),
+            _card("Mystical Tutor", description="Search your library for a card", cmc=1, edhrec_rank=9),
+            _card("Flooded Strand", type_="Land", cmc=0, edhrec_rank=10),
+            _card("Polluted Delta", type_="Land", cmc=0, edhrec_rank=11),
+            _card("Scalding Tarn", type_="Land", cmc=0, edhrec_rank=12),
+            _card("Misty Rainforest", type_="Land", cmc=0, edhrec_rank=13),
+            _card("Verdant Catacombs", type_="Land", cmc=0, edhrec_rank=14),
+        ]
+        # Pad to 100 cards with basic lands (cmc=0, land type, high edhrec_rank)
+        padding = [_card(f"Forest {i}", type_="Basic Land — Forest", cmc=0) for i in range(86)]
+        result = estimate_power_level(cards + padding)
+        assert result.score >= 6.0


### PR DESCRIPTION
## Summary

Three deck-related features for the MTG collection manager:

- **Cross-Deck Card Allocation Visualization (#130)** — New `/allocations` page showing all collection cards as a grid with color-coded badges (green=available, orange=in 1 deck, red=in multiple). Click a card to see deck assignments and remove allocations. New `GET /api/cards/allocations` endpoint.

- **Mobile-Optimized Deck Management (#132)** — Full-screen modals on mobile, touch-friendly 44px+ tap targets, swipe-to-remove gesture on card rows, sticky bottom action bar. New `useSwipeToRemove` hook and `fullScreenOnMobile` prop on `AccessibleModal`. Pure frontend changes.

- **Bracket/Power Level Auto-Estimation (#133)** — Heuristic scoring engine analyzing fast mana, tutors, combos, avg CMC, land quality, and staple density to produce a 1-10 score and Commander Bracket (1-4). New `GET /api/decks/{id}/power-level` endpoint with 5-min in-process cache. Score badges on deck tiles and detail modal.

Closes #130
Closes #132
Closes #133

## Changes

### Backend
- New endpoint: `GET /api/cards/allocations` (card-to-deck allocation data)
- New endpoint: `GET /api/decks/{id}/power-level` (power level scoring)
- New service: `deckdex/services/power_level.py` (pure scoring engine)
- New service: `backend/api/services/power_level_service.py` (caching layer)
- `deck_repository.py`: new `get_all_card_allocations` method, `updated_at` bump on all card mutations

### Frontend
- New page: `/allocations` with `AllocationTile` and `AllocationPopover` components
- New hook: `useSwipeToRemove` for touch gesture support
- `AccessibleModal`: new `fullScreenOnMobile` prop
- `DeckDetailModal`: mobile layout (hidden image panel, sticky action bar, swipe-to-remove rows, power level header)
- `DeckCardPickerModal`, `DeckImportModal`: full-screen on mobile
- `DeckBuilder`: power level badges on deck tiles, mobile tile sizing
- i18n: `allocations`, `powerLevel`, `deckDetail.mobileActions` namespaces (EN + ES)

## Test plan
- [ ] Backend: `pytest tests/test_allocations.py tests/test_power_level.py tests/test_deck_power_level_api.py`
- [ ] Frontend: `npx vitest run` (90 tests across 16 files)
- [ ] TypeScript: `npx tsc --noEmit`
- [ ] Lint: `npx eslint src/` and `ruff check .`
- [ ] Manual: verify `/allocations` page, mobile deck modal, power level badges